### PR TITLE
feat: Make Release Please workflow manual-only and restrict to owners

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,7 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -18,6 +16,21 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Check actor permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          PERMISSION=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission')
+          echo "Actor: ${ACTOR}, Permission: ${PERMISSION}"
+          if [ "$PERMISSION" != "admin" ]; then
+            echo "::error::Only repository owners (admin) can run this workflow"
+            exit 1
+          fi
+          echo "Permission check passed"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 概要

Release Please ワークフローを手動実行のみに変更し、リポジトリ owner のみが実行できるように制限します。

## 関連Issue

Closes #2

## 変更の種類

- [x] `feature` - 新機能追加
- [ ] `fix` - バグ修正
- [ ] `refactor` - リファクタリング
- [ ] `chore` - 設定・依存関係・ビルド
- [ ] `docs` - ドキュメント
- [ ] `style` - UIスタイル変更
- [ ] `perf` - パフォーマンス改善
- [ ] `test` - テスト追加・修正

## 変更内容

- トリガーを `push` から `workflow_dispatch` に変更
- 権限チェックステップを追加（GitHub API で実行者の権限を確認）
- `admin` 以外のユーザーが実行した場合はエラーで停止

## テスト内容

- PRマージ後、GitHub Actions タブから「Run workflow」ボタンが表示されることを確認
- owner アカウントで手動実行が成功することを確認
- （可能であれば）owner 以外のアカウントで実行が拒否されることを確認

## チェックリスト

- [x] 既存の機能に影響がないことを確認した

## レビュアーへのコメント

- 環境変数を使用してコマンドインジェクションを防止しています
- `gh api` を使用して実行者の権限レベルを取得しています