### PR TITLE
fix: auto-create tags when release PR is merged

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,9 @@
 name: Release Please
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -16,7 +19,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - name: Check actor permission
+      - name: Check actor permission (manual trigger only)
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}
@@ -26,10 +30,10 @@ jobs:
           PERMISSION=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission')
           echo "Actor: ${ACTOR}, Permission: ${PERMISSION}"
           if [ "$PERMISSION" != "admin" ]; then
-            echo "::error::Only repository owners (admin) can run this workflow"
+            echo "::error::Only repository owners (admin) can run this workflow manually"
             exit 1
           fi
-          echo "Permission check passed"
+          echo "✅ Permission check passed: ${ACTOR} has ${PERMISSION} access"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,33 +63,58 @@ jobs:
           fi
           echo "Configuration files validated successfully"
 
-      - name: Run Release Please
+      # pushトリガー時: タグ作成のみ（PR作成しない）
+      - name: Release Please (create tag on merge)
+        if: github.event_name == 'push'
+        id: release-push
         uses: googleapis/release-please-action@v4
-        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
+
+      # 手動トリガー時: PR作成のみ（タグ作成しない）
+      - name: Release Please (create PR manually)
+        if: github.event_name == 'workflow_dispatch'
+        id: release-manual
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
 
       - name: Output Release Status
         env:
-          RELEASE_CREATED: ${{ steps.release.outputs.release_created }}
-          PR: ${{ steps.release.outputs.pr }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-          VERSION: ${{ steps.release.outputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_CREATED: ${{ steps.release-push.outputs.release_created }}
+          PUSH_PR: ${{ steps.release-push.outputs.pr }}
+          PUSH_TAG_NAME: ${{ steps.release-push.outputs.tag_name }}
+          PUSH_VERSION: ${{ steps.release-push.outputs.version }}
+          MANUAL_PR: ${{ steps.release-manual.outputs.pr }}
           REPO: ${{ github.repository }}
         run: |
           set -e
           echo "## Release Please Summary" >> $GITHUB_STEP_SUMMARY
-          if [ "$RELEASE_CREATED" = "true" ]; then
-            echo "### Release Created" >> $GITHUB_STEP_SUMMARY
-            echo "- **Tag:** ${TAG_NAME}" >> $GITHUB_STEP_SUMMARY
-            echo "- **Version:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
-            echo "[View Release](https://github.com/${REPO}/releases/tag/${TAG_NAME})" >> $GITHUB_STEP_SUMMARY
-          elif [ -n "$PR" ]; then
-            echo "### Release PR Updated" >> $GITHUB_STEP_SUMMARY
-            echo "Release PR: ${PR}" >> $GITHUB_STEP_SUMMARY
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "### Trigger: Push to main" >> $GITHUB_STEP_SUMMARY
+            if [ "$RELEASE_CREATED" = "true" ]; then
+              echo "### ✅ Release Created" >> $GITHUB_STEP_SUMMARY
+              echo "- **Tag:** ${PUSH_TAG_NAME}" >> $GITHUB_STEP_SUMMARY
+              echo "- **Version:** ${PUSH_VERSION}" >> $GITHUB_STEP_SUMMARY
+              echo "[View Release](https://github.com/${REPO}/releases/tag/${PUSH_TAG_NAME})" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### No Release Action" >> $GITHUB_STEP_SUMMARY
+              echo "No pending release PR merge detected." >> $GITHUB_STEP_SUMMARY
+            fi
           else
-            echo "### No Release Action" >> $GITHUB_STEP_SUMMARY
-            echo "No releasable commits since last release." >> $GITHUB_STEP_SUMMARY
+            echo "### Trigger: Manual (workflow_dispatch)" >> $GITHUB_STEP_SUMMARY
+            if [ -n "$MANUAL_PR" ]; then
+              echo "### ✅ Release PR Created/Updated" >> $GITHUB_STEP_SUMMARY
+              echo "Release PR: ${MANUAL_PR}" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### No Release Action" >> $GITHUB_STEP_SUMMARY
+              echo "No releasable commits since last release." >> $GITHUB_STEP_SUMMARY
+            fi
           fi


### PR DESCRIPTION
## 概要

Release PRマージ後にタグが自動作成されない問題を修正しました。release-please-actionの `skip-github-pull-request` と `skip-github-release` オプションを使い、PR作成とタグ作成を分離しています。

## 関連Issue

なし

## 変更の種類

- [ ] `feature` - 新機能追加
- [x] `fix` - バグ修正
- [ ] `refactor` - リファクタリング
- [ ] `chore` - 設定・依存関係・ビルド
- [ ] `docs` - ドキュメント
- [ ] `style` - UIスタイル変更
- [ ] `perf` - パフォーマンス改善
- [ ] `test` - テスト追加・修正

## 変更内容

- `on:` トリガーに `push: branches: - main` を追加
- pushトリガー時: タグ作成のみ実行 (`skip-github-pull-request: true`)
- 手動トリガー時: PR作成のみ実行 (`skip-github-release: true`)
- 権限チェックを手動トリガー時のみに制限
- サマリー出力を両方のケースに対応するよう修正

## テスト内容

- ワークフロー構文の検証済み
- このPRをマージすると、pushトリガーでrelease-pleaseが実行され、マージ済みのv0.5.0 Release PRに対応するタグが自動作成される

## スクリーンショット

N/A

## チェックリスト

- [x] `npm run format && npm run lint && npm run build` を実行し、エラーがないことを確認した
- [x] 既存の機能に影響がないことを確認した
- [ ] ダークモードで表示を確認した（UI変更の場合）
- [ ] モバイル表示を確認した（UI変更の場合）

## レビュアーへのコメント

このPRをマージすると、v0.5.0のタグが自動的に作成されます。