### PR TITLE
build: enable building on Intel Macs and show target architecture in A…

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,7 +7,7 @@ This document describes how to build DevTools from source.
 ## Requirements
 
 ### Platform
-- **macOS 15.0 or later** (Apple Silicon / arm64 only)
+- **macOS 15.0 or later** (Apple Silicon / arm64 and Intel / x86_64)
 
 ### Tools
 - **CMake**: 3.21.1 or later
@@ -74,8 +74,8 @@ vcpkg install
 # Create build directory
 mkdir build && cd build
 
-# Configure
-cmake .. -DVCPKG_TARGET_TRIPLET=arm64-osx
+# Configure (vcpkg triplet is auto-detected based on architecture)
+cmake ..
 
 # Build
 make
@@ -88,23 +88,19 @@ make -j$(sysctl -n hw.ncpu)
 
 1. Open `CMakeLists.txt` in Qt Creator
 2. Enable the vcpkg plugin in Qt Creator settings
-3. Add the following CMake argument:
-   ```
-   -DVCPKG_TARGET_TRIPLET=arm64-osx
-   ```
-4. Configure the project
-5. Build using the Build button or `Cmd+B`
+3. Configure the project (vcpkg triplet is auto-detected)
+4. Build using the Build button or `Cmd+B`
 
 ### Build Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `ENABLE_UNIT_TEST` | OFF | Enable unit tests |
-| `VCPKG_TARGET_TRIPLET` | auto | Set to `arm64-osx` for Apple Silicon |
+| `VCPKG_TARGET_TRIPLET` | auto | Auto-detected (`arm64-osx` on Apple Silicon, `x64-osx` on Intel). Can be overridden manually. |
 
 Example with options:
 ```bash
-cmake .. -DENABLE_UNIT_TEST=ON -DVCPKG_TARGET_TRIPLET=arm64-osx
+cmake .. -DENABLE_UNIT_TEST=ON
 ```
 
 ## Running Tests
@@ -168,9 +164,15 @@ The generated documentation will be in `build/doxygen/html/`.
 
 1. **Set Qt6_DIR** environment variable:
    ```bash
+   # Apple Silicon
    export Qt6_DIR=/opt/homebrew/lib/cmake/Qt6
+   # Intel Mac
+   export Qt6_DIR=/usr/local/lib/cmake/Qt6
    ```
 2. **Or pass it to CMake**:
    ```bash
+   # Apple Silicon
    cmake .. -DQt6_DIR=/opt/homebrew/lib/cmake/Qt6
+   # Intel Mac
+   cmake .. -DQt6_DIR=/usr/local/lib/cmake/Qt6
    ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,9 @@ set(APP_INFO_FILE app_info.autogen.cpp)
 
 # プラットフォーム固有の設定
 if(APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "15.0") # NOTE: 現状arm64専用のため
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "15.0")
+    message(STATUS "Target architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+    message(STATUS "macOS deployment target: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
     set(BUNDLE_ID_OPTION MACOSX_BUNDLE_GUI_IDENTIFIER com.lotusandcompanyinc.dev-tools)
 
     # アイコンを設定
@@ -63,7 +65,7 @@ endif()
 set(SH_FILE ${CMAKE_CURRENT_SOURCE_DIR}/generate_app_info.sh)
 file(CHMOD ${SH_FILE} PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 add_custom_target(${PROJECT_NAME}_app_info
-    COMMAND ${SH_FILE} "${CMAKE_PROJECT_VERSION}${DevTools_VERSION_SUFFIX}" "${OS_NAME}" ${CMAKE_SYSTEM_VERSION} ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}
+    COMMAND ${SH_FILE} "${CMAKE_PROJECT_VERSION}${DevTools_VERSION_SUFFIX}" "${OS_NAME}" ${CMAKE_SYSTEM_VERSION} ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} ${CMAKE_SYSTEM_PROCESSOR}
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
@@ -348,9 +350,7 @@ if(${GENERATOR_LOWER} STREQUAL "xcode")
         WIN32_EXECUTABLE TRUE
         # 機能しないので削除
         #INSTALL_RPATH "@executable_path/../Frameworks;@executable_path/../Libs"
-        # NOTE: x86_64もサポートするのが望ましいが、静的リンクライブラリがビルドできなかった。
-        #       また、パッケージマネージャと競合する可能性がある。
-        XCODE_ATTRIBUTE_ARCHS   "arm64"
+        XCODE_ATTRIBUTE_ARCHS   "${CMAKE_SYSTEM_PROCESSOR}"
         XCODE_ATTRIBUTE_SDKROOT "macosx"
         XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH  "YES"
         XCODE_ATTRIBUTE_PRODUCT_NAME    ${PROJECT_NAME}

--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ A unified desktop application that combines various development tools into a sin
 
 ## Requirements
 
-- **Platform**: macOS 15.0+ (Apple Silicon / arm64 only)
+- **Platform**: macOS 15.0+ (Apple Silicon / arm64 and Intel / x86_64)
 - **Qt**: 6.x
 - **CMake**: 3.21.1+
 - **C++ Compiler**: C++17 compatible

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ This guide provides detailed instructions for setting up the DevTools developmen
 ## System Requirements
 
 ### Platform
-- **macOS 15.0 or later** (Apple Silicon / arm64 only)
+- **macOS 15.0 or later** (Apple Silicon / arm64 and Intel / x86_64)
 
 ### Required Tools
 | Tool | Version | Purpose |
@@ -111,8 +111,8 @@ This installs:
 # Create build directory
 mkdir build && cd build
 
-# Configure with CMake
-cmake .. -DVCPKG_TARGET_TRIPLET=arm64-osx
+# Configure with CMake (vcpkg triplet is auto-detected based on architecture)
+cmake ..
 
 # Build (using all available cores)
 make -j$(sysctl -n hw.ncpu)
@@ -141,8 +141,7 @@ open DevTools.app
 3. Ensure a Qt 6.x kit is configured
 4. Enable the vcpkg plugin in **Preferences > CMake > vcpkg**
 5. Open `CMakeLists.txt` from the project root
-6. Add CMake argument: `-DVCPKG_TARGET_TRIPLET=arm64-osx`
-7. Configure and build
+6. Configure and build (vcpkg triplet is auto-detected)
 
 ### VS Code
 
@@ -151,23 +150,13 @@ open DevTools.app
    - CMake Tools
    - clangd (optional, for better intellisense)
 
-2. Create `.vscode/settings.json`:
-   ```json
-   {
-     "cmake.configureArgs": [
-       "-DVCPKG_TARGET_TRIPLET=arm64-osx"
-     ]
-   }
-   ```
-
-3. Use the CMake Tools extension to configure and build
+2. Use the CMake Tools extension to configure and build (vcpkg triplet is auto-detected)
 
 ### CLion
 
 1. Open the project folder
 2. Go to **Preferences > Build, Execution, Deployment > CMake**
-3. Add CMake option: `-DVCPKG_TARGET_TRIPLET=arm64-osx`
-4. Reload CMake project
+3. Reload CMake project (vcpkg triplet is auto-detected)
 
 ## Verifying Installation
 

--- a/docs/ja/BUILD.md
+++ b/docs/ja/BUILD.md
@@ -7,7 +7,7 @@
 ## 必要要件
 
 ### プラットフォーム
-- **macOS 15.0以上**（Apple Silicon / arm64専用）
+- **macOS 15.0以上**（Apple Silicon / arm64 および Intel / x86_64）
 
 ### ツール
 - **CMake**: 3.21.1以上
@@ -74,8 +74,8 @@ vcpkg install
 # ビルドディレクトリを作成
 mkdir build && cd build
 
-# 構成
-cmake .. -DVCPKG_TARGET_TRIPLET=arm64-osx
+# 構成（vcpkgトリプレットはアーキテクチャに基づいて自動検出）
+cmake ..
 
 # ビルド
 make
@@ -88,23 +88,19 @@ make -j$(sysctl -n hw.ncpu)
 
 1. Qt Creatorで `CMakeLists.txt` を開く
 2. Qt Creatorの設定でvcpkgプラグインを有効にする
-3. 以下のCMake引数を追加：
-   ```
-   -DVCPKG_TARGET_TRIPLET=arm64-osx
-   ```
-4. プロジェクトを構成
-5. ビルドボタンまたは `Cmd+B` でビルド
+3. プロジェクトを構成（vcpkgトリプレットは自動検出）
+4. ビルドボタンまたは `Cmd+B` でビルド
 
 ### ビルドオプション
 
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
 | `ENABLE_UNIT_TEST` | OFF | ユニットテストを有効にする |
-| `VCPKG_TARGET_TRIPLET` | auto | Apple Siliconの場合は `arm64-osx` を設定 |
+| `VCPKG_TARGET_TRIPLET` | auto | 自動検出（Apple Siliconでは `arm64-osx`、Intelでは `x64-osx`）。手動指定も可能。 |
 
 オプション指定の例：
 ```bash
-cmake .. -DENABLE_UNIT_TEST=ON -DVCPKG_TARGET_TRIPLET=arm64-osx
+cmake .. -DENABLE_UNIT_TEST=ON
 ```
 
 ## テストの実行
@@ -168,11 +164,17 @@ make DevTools_docs
 
 1. **Qt6_DIR環境変数を設定**:
    ```bash
+   # Apple Silicon
    export Qt6_DIR=/opt/homebrew/lib/cmake/Qt6
+   # Intel Mac
+   export Qt6_DIR=/usr/local/lib/cmake/Qt6
    ```
 2. **またはCMakeに渡す**:
    ```bash
+   # Apple Silicon
    cmake .. -DQt6_DIR=/opt/homebrew/lib/cmake/Qt6
+   # Intel Mac
+   cmake .. -DQt6_DIR=/usr/local/lib/cmake/Qt6
    ```
 
 ## 配布

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -40,7 +40,7 @@
 
 ## 必要環境
 
-- **OS**: macOS 15.0以上（Apple Silicon / arm64 専用）
+- **OS**: macOS 15.0以上（Apple Silicon / arm64 および Intel / x86_64）
 - **Qt**: 6.x
 - **CMake**: 3.21.1以上
 - **C++ コンパイラ**: C++17 対応
@@ -130,8 +130,7 @@ CMakeの設定で `ENABLE_UNIT_TEST` をONにするとテストができるよ�
 
 Qt以外の外部ライブラリを利用する場合は[vcpkg](https://vcpkg.io/)を使います。
 Qt Creatorの方でプラグインを有効にしてください。
-macOSではなぜかarm64と判定されないのでCMakeの引数に以下を追加してください。
-`-DVCPKG_TARGET_TRIPLET=arm64-osx`
+vcpkgトリプレットはアーキテクチャに基づいて自動検出されます（arm64→`arm64-osx`、x86_64→`x64-osx`）。手動指定する場合はCMakeの引数に `-DVCPKG_TARGET_TRIPLET=arm64-osx` などを追加してください。
 
 また、小規模のものであれば `git submodule` で追加しても構いません。
 submoduleの場合は普通にコードを追加すれば動くはずです。

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -23,7 +23,10 @@ Could not find a package configuration file provided by "Qt6"
 2. Set Qt6_DIR:
    ```bash
    export Qt6_DIR=/opt/homebrew/lib/cmake/Qt6
+   # Apple Silicon
    cmake .. -DQt6_DIR=/opt/homebrew/lib/cmake/Qt6
+   # Intel Mac
+   cmake .. -DQt6_DIR=/usr/local/lib/cmake/Qt6
    ```
 
 #### vcpkg Packages Not Found
@@ -142,9 +145,9 @@ Cannot be opened because the developer cannot be verified
    file DevTools.app/Contents/MacOS/DevTools
    ```
 
-2. Rebuild with correct triplet:
+2. Rebuild (vcpkg triplet is auto-detected based on architecture):
    ```bash
-   cmake .. -DVCPKG_TARGET_TRIPLET=arm64-osx
+   cmake ..
    ```
 
 ### Feature-Specific Issues

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -10,9 +10,9 @@ DevTools is a unified desktop application that combines various development tool
 
 Currently, DevTools supports:
 - **macOS 15.0 or later**
-- **Apple Silicon (arm64) only**
+- **Apple Silicon (arm64) and Intel (x86_64)**
 
-Intel Mac support is not currently available.
+Note: The application requires macOS 15.0+ to run (Apple Silicon only). Intel Macs can be used for building from source.
 
 ### Is DevTools free?
 
@@ -47,7 +47,10 @@ See [Installation Guide](../getting-started/installation.md) for details.
 Qt might not be in your PATH. Set the Qt6_DIR:
 
 ```bash
+# Apple Silicon
 export Qt6_DIR=/opt/homebrew/lib/cmake/Qt6
+# Intel Mac
+export Qt6_DIR=/usr/local/lib/cmake/Qt6
 ```
 
 Or install via Homebrew:
@@ -178,9 +181,9 @@ Use Terminal.app for these.
 
 There are no immediate plans for Windows or Linux support. The current focus is on macOS.
 
-### Will Intel Mac be supported?
+### Is Intel Mac supported?
 
-There are no immediate plans for Intel Mac support. Apple Silicon (arm64) is the primary target.
+Intel Macs can be used for building DevTools from source. However, running the application requires macOS 15.0 or later, which is only available on Apple Silicon Macs.
 
 ### What features are planned?
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -141,7 +141,7 @@ To change language:
 ## System Requirements
 
 - **OS**: macOS 15.0 or later
-- **Architecture**: Apple Silicon (arm64)
+- **Architecture**: Apple Silicon (arm64) and Intel (x86_64)
 - **Memory**: 4GB RAM recommended
 - **Storage**: 100MB free space
 

--- a/generate_app_info.sh
+++ b/generate_app_info.sh
@@ -3,6 +3,7 @@
 # $3: OS version
 # $4: Compiler name
 # $5: Compiler version
+# $6: Target architecture
 
 # Sample:
 #
@@ -13,6 +14,7 @@
 #   constexpr const char* OS_VERSION = "x.y.z";
 #   constexpr const char* COMPILER_NAME = "compiler";
 #   constexpr const char* COMPILER_VERSION = "x.y.z";
+#   constexpr const char* TARGET_ARCH = "arm64";
 #   }
 
 target_file="app_info.autogen.cpp"
@@ -25,5 +27,6 @@ echo "constexpr const char* OS_NAME = \"$2\";" >> $target_file
 echo "constexpr const char* OS_VERSION = \"$3\";" >> $target_file
 echo "constexpr const char* COMPILER_NAME = \"$4\";" >> $target_file
 echo "constexpr const char* COMPILER_VERSION = \"$5\";" >> $target_file
+echo "constexpr const char* TARGET_ARCH = \"$6\";" >> $target_file
 
 echo "}" >> $target_file

--- a/gui/menubar/about_devtools_dialog.cpp
+++ b/gui/menubar/about_devtools_dialog.cpp
@@ -14,7 +14,8 @@ AboutDevToolsDialog::AboutDevToolsDialog(QWidget *parent)
 
     ui->appVersion->setText(DevTools::APP_VERSION);
     ui->revision->setText(DevTools::GIT_REVISION);
-    ui->buildEnv->setText(QString(DevTools::OS_NAME) + " " + QString(DevTools::OS_VERSION) + ", " +
+    ui->buildEnv->setText(QString(DevTools::OS_NAME) + " " + QString(DevTools::OS_VERSION) + " (" +
+                          QString(DevTools::TARGET_ARCH) + "), " +
                           QString(DevTools::COMPILER_NAME) + " " +
                           QString(DevTools::COMPILER_VERSION));
     ui->qtVersion->setText(qVersion());


### PR DESCRIPTION
## Description / 説明

Please include a summary of the changes and which issue is fixed.
変更の概要と修正されたIssueを記載してください。

Add x86_64 support by auto-detecting vcpkg triplet and using CMAKE_SYSTEM_PROCESSOR for Xcode ARCHS. Display TARGET_ARCH in the About dialog build environment info. Update all documentation to reflect dual-architecture support.

Fixes #14 (issue)

## Type of Change / 変更の種類

Please check the relevant option:
該当するものにチェックを入れてください:

- [x] Bug fix (non-breaking change which fixes an issue) / バグ修正（Issueを修正する非破壊的変更）
- [ ] New feature (non-breaking change which adds functionality) / 新機能（機能を追加する非破壊的変更）
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) / 破壊的変更（既存の機能が期待どおりに動作しなくなる修正または機能）
- [x] Documentation update / ドキュメントの更新
- [ ] Refactoring / リファクタリング
- [ ] Other (please describe) / その他（説明してください）

## Checklist / チェックリスト

- [ ] My code follows the style guidelines of this project / コードはこのプロジェクトのスタイルガイドラインに従っています
- [ ] I have performed a self-review of my own code / 自分のコードのセルフレビューを行いました
- [ ] I have commented my code, particularly in hard-to-understand areas / 特に理解しにくい部分にコメントを追加しました
- [x] I have made corresponding changes to the documentation / ドキュメントに対応する変更を加えました
- [x] My changes generate no new warnings / 変更によって新しい警告が発生していません
- [ ] I have added tests that prove my fix is effective or that my feature works / 修正が有効であること、または機能が動作することを証明するテストを追加しました
- [ ] New and existing unit tests pass locally with my changes / 変更により新規および既存のユニットテストがローカルでパスします

## Screenshots / スクリーンショット

If applicable, add screenshots to help explain your changes.
該当する場合は、変更を説明するためのスクリーンショットを追加してください。

## Additional Notes / 追加メモ

Add any additional notes for reviewers here.
レビュアー向けの追加メモがあれば記載してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Intel/x86_64 Macサポートを追加。Apple Siliconに加えてIntel ベースのMacでのビルドが可能になりました。

* **ドキュメント**
  * ビルド手順を簡素化。vcpkgトリプレットが自動検出されるようになり、手動指定が不要になりました。
  * Qt6_DIRガイダンスを更新。Apple SiliconとIntel Mac用の個別パスを提供。
  * プラットフォームサポート情報をドキュメント全体で更新（英語および日本語版）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->