### PR TITLE
docs: improve Doxygen configuration and page layout

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,8 @@ This document describes how to build DevTools from source.
 - yaml-cpp
 
 ### Optional
-- **Doxygen**: For generating API documentation
+- **Doxygen**: 1.16+ (API documentation generation)
+- **GraphViz**: For class diagrams and dependency graphs in documentation (optional)
 - **Qt Creator**: 18.0.1+ (IDE with Qt integration)
 - **Ninja**: 1.12.1+ (Fast build tool)
 - **Qt Installer Framework**: 4.10 (Application packaging)
@@ -122,12 +123,22 @@ ctest
 
 ## Generating Documentation
 
-Doxygen is required to generate API documentation.
+Doxygen 1.16+ is required to generate API documentation.
 
 ### Install Doxygen
 ```bash
 brew install doxygen
 ```
+
+### Install GraphViz (Optional)
+
+GraphViz enables class inheritance diagrams, collaboration diagrams, and include dependency graphs.
+
+```bash
+brew install graphviz
+```
+
+If GraphViz is not installed, documentation will be generated without diagrams.
 
 ### Generate Documentation
 ```bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core Widgets LinguistTools Sql Network)
 # vcpkgのパッケージを探す
 find_package(toml11 CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
-# Doxygenを探す（1.16以上を推奨）
+# Doxygenを探す（1.16以上が必要）
 find_package(Doxygen 1.16)
 
 qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES ja_JP en)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ find_package(Qt6 REQUIRED COMPONENTS Core Widgets LinguistTools Sql Network)
 # vcpkgのパッケージを探す
 find_package(toml11 CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
-# Doxygenを探す
-find_package(Doxygen)
+# Doxygenを探す（1.16以上を推奨）
+find_package(Doxygen 1.16)
 
 qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES ja_JP en)
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,10 +12,16 @@ DevTools uses Doxygen for API documentation generation. The full API reference i
 
 ### Prerequisites
 
-Install Doxygen:
+Install Doxygen (1.16+):
 
 ```bash
 brew install doxygen
+```
+
+Optionally, install GraphViz to enable class diagrams and dependency graphs:
+
+```bash
+brew install graphviz
 ```
 
 ### Generate

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -74,10 +74,16 @@ vcpkg version
 
 ### 3. Install Additional Tools
 
-#### Doxygen (Optional)
+#### Doxygen (Optional, 1.16+)
 
 ```bash
 brew install doxygen
+```
+
+#### GraphViz (Optional, for documentation diagrams)
+
+```bash
+brew install graphviz
 ```
 
 #### clang-format and clang-tidy (For development)

--- a/docs/ja/BUILD.md
+++ b/docs/ja/BUILD.md
@@ -20,7 +20,8 @@
 - yaml-cpp
 
 ### オプション
-- **Doxygen**: APIドキュメント生成用
+- **Doxygen**: 1.16以上（APIドキュメント生成用）
+- **GraphViz**: クラス図・依存関係グラフの生成用（オプション）
 - **Qt Creator**: 18.0.1以上（Qt統合IDE）
 - **Ninja**: 1.12.1以上（高速ビルドツール）
 - **Qt Installer Framework**: 4.10（アプリケーションパッケージング）
@@ -122,12 +123,22 @@ ctest
 
 ## ドキュメントの生成
 
-APIドキュメントの生成にはDoxygenが必要です。
+APIドキュメントの生成にはDoxygen 1.16以上が必要です。
 
 ### Doxygenのインストール
 ```bash
 brew install doxygen
 ```
+
+### GraphVizのインストール（オプション）
+
+GraphVizをインストールすると、クラス継承図・コラボレーション図・インクルード依存図が生成されます。
+
+```bash
+brew install graphviz
+```
+
+GraphVizがインストールされていない場合、図表なしでドキュメントが生成されます。
 
 ### ドキュメントの生成
 ```bash

--- a/doxygen/DevToolsDocs.cmake
+++ b/doxygen/DevToolsDocs.cmake
@@ -8,6 +8,9 @@ set(DOXYGEN_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # copy icon
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/dev-tools_icon.doxygen.png DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/doxygen/)
 
+# copy layout file
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/DoxygenLayout.xml DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/doxygen/)
+
 # request to configure the file
 configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 message("Doxygen build started")

--- a/doxygen/DevToolsDocs.cmake
+++ b/doxygen/DevToolsDocs.cmake
@@ -5,6 +5,16 @@ set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Doxyfile.in)
 set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen/Doxyfile)
 set(DOXYGEN_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+# check GraphViz
+find_program(DOT_EXECUTABLE dot)
+if(DOT_EXECUTABLE)
+  set(DOXYGEN_HAVE_DOT "YES")
+  message(STATUS "GraphViz found: ${DOT_EXECUTABLE}")
+else()
+  set(DOXYGEN_HAVE_DOT "NO")
+  message(STATUS "GraphViz not found - diagrams will be disabled")
+endif()
+
 # copy icon
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/dev-tools_icon.doxygen.png DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/doxygen/)
 

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -7,6 +7,9 @@ PROJECT_ICON = "doxygen/dev-tools_icon.doxygen.png"
 INPUT = @CMAKE_CURRENT_SOURCE_DIR@/docs/ @CMAKE_CURRENT_SOURCE_DIR@/core/ @CMAKE_CURRENT_SOURCE_DIR@/gui/
 FILE_PATTERNS = *.cpp *.h *.dox *.md
 RECURSIVE = YES
+
+# レイアウトファイル
+LAYOUT_FILE = doxygen/DoxygenLayout.xml
 OUTPUT_DIRECTORY = doxygen
 #EXTRACT_ALL = YES
 STRIP_FROM_PATH = @CMAKE_CURRENT_SOURCE_DIR@

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -7,6 +7,9 @@ PROJECT_ICON = "doxygen/dev-tools_icon.doxygen.png"
 INPUT = @CMAKE_CURRENT_SOURCE_DIR@/docs/ @CMAKE_CURRENT_SOURCE_DIR@/core/ @CMAKE_CURRENT_SOURCE_DIR@/gui/
 FILE_PATTERNS = *.cpp *.h *.dox *.md
 RECURSIVE = YES
+# サードパーティコードと日本語ドキュメントを除外
+EXCLUDE_PATTERNS = *qrcodegen.cpp *qrcodegen.hpp
+EXCLUDE = @CMAKE_CURRENT_SOURCE_DIR@/docs/ja
 
 # レイアウトファイル
 LAYOUT_FILE = doxygen/DoxygenLayout.xml
@@ -36,10 +39,48 @@ MATHJAX_VERSION = MathJax_3
 MATHJAX_EXTENSIONS = ams
 HTML_FORMULA_FORMAT = svg
 
+# ツリービューナビゲーション（左サイドバーに階層表示）
+GENERATE_TREEVIEW = YES
+FULL_SIDEBAR = NO
+
+# カラースキーム（ライト/ダーク自動切替）
+HTML_COLORSTYLE = AUTO_LIGHT
+
+# コードブロックのコピーボタン
+HTML_COPY_CLIPBOARD = YES
+
+# ビルドの並列化
+NUM_PROC_THREADS = 0
+
+# タイムスタンプをヘッダーに含めない（ビルド再現性）
+TIMESTAMP = NO
+
+# メインページ
+USE_MDFILE_AS_MAINPAGE = @CMAKE_CURRENT_SOURCE_DIR@/docs/index.md
+
+# 警告設定（未ドキュメントのメンバーやコメントエラーを検出）
+WARNINGS = YES
+WARN_IF_UNDOCUMENTED = YES
+WARN_IF_DOC_ERROR = YES
+WARN_IF_INCOMPLETE_DOC = YES
+WARN_AS_ERROR = NO
+WARN_LOGFILE = doxygen/doxygen_warnings.log
+
 # ソースコードを含めない
 VERBATIM_HEADERS = NO
 SOURCE_BROWSER = NO
 REFERENCES_LINK_SOURCE = NO
+
+# GraphViz（クラス図・依存図の自動生成）
+HAVE_DOT = @DOXYGEN_HAVE_DOT@
+CLASS_GRAPH = YES
+COLLABORATION_GRAPH = YES
+INCLUDE_GRAPH = YES
+INCLUDED_BY_GRAPH = YES
+CALL_GRAPH = NO
+CALLER_GRAPH = NO
+DOT_IMAGE_FORMAT = svg
+INTERACTIVE_SVG = YES
 
 # プリプロセッサを動かす
 ENABLE_PREPROCESSING = YES

--- a/doxygen/DoxygenLayout.xml
+++ b/doxygen/DoxygenLayout.xml
@@ -119,7 +119,7 @@
       <functions visible="yes" title=""/>
       <variables visible="yes" title=""/>
       <properties visible="yes" title=""/>
-      <membergroups visible="yes" visible="yes"/>
+      <membergroups visible="yes"/>
     </memberdecl>
     <detaileddescription visible="yes" title=""/>
     <memberdef>
@@ -167,7 +167,7 @@
       <functions visible="yes" title=""/>
       <variables visible="yes" title=""/>
       <properties visible="yes" title=""/>
-      <membergroups visible="yes" visible="yes"/>
+      <membergroups visible="yes"/>
     </memberdecl>
     <detaileddescription visible="yes" title=""/>
     <memberdef>

--- a/doxygen/DoxygenLayout.xml
+++ b/doxygen/DoxygenLayout.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doxygenlayout version="2.0">
+  <!-- Navigation index tabs for HTML output -->
+  <navindex>
+    <tab type="mainpage" visible="yes" title=""/>
+    <tab type="pages" visible="yes" title="" intro=""/>
+    <tab type="topics" visible="no" title="" intro=""/>
+    <tab type="modules" visible="no" title="" intro="">
+      <tab type="modulelist" visible="yes" title="" intro=""/>
+      <tab type="modulemembers" visible="yes" title="" intro=""/>
+    </tab>
+    <tab type="classes" visible="yes" title="">
+      <tab type="classlist" visible="yes" title="" intro=""/>
+      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>
+      <tab type="hierarchy" visible="yes" title="" intro=""/>
+      <tab type="classmembers" visible="yes" title="" intro=""/>
+    </tab>
+    <tab type="namespaces" visible="yes" title="">
+      <tab type="namespacelist" visible="yes" title="" intro=""/>
+      <tab type="namespacemembers" visible="yes" title="" intro=""/>
+    </tab>
+    <tab type="concepts" visible="no" title="">
+    </tab>
+    <tab type="interfaces" visible="yes" title="">
+      <tab type="interfacelist" visible="yes" title="" intro=""/>
+      <tab type="interfaceindex" visible="$ALPHABETICAL_INDEX" title=""/>
+      <tab type="interfacehierarchy" visible="yes" title="" intro=""/>
+    </tab>
+    <tab type="structs" visible="yes" title="">
+      <tab type="structlist" visible="yes" title="" intro=""/>
+      <tab type="structindex" visible="$ALPHABETICAL_INDEX" title=""/>
+    </tab>
+    <tab type="exceptions" visible="yes" title="">
+      <tab type="exceptionlist" visible="yes" title="" intro=""/>
+      <tab type="exceptionindex" visible="$ALPHABETICAL_INDEX" title=""/>
+      <tab type="exceptionhierarchy" visible="yes" title="" intro=""/>
+    </tab>
+    <tab type="files" visible="yes" title="">
+      <tab type="filelist" visible="yes" title="" intro=""/>
+      <tab type="globals" visible="yes" title="" intro=""/>
+    </tab>
+    <tab type="examples" visible="yes" title="" intro=""/>
+  </navindex>
+
+  <!-- Layout definition for a class page -->
+  <class>
+    <briefdescription visible="yes"/>
+    <includes visible="$SHOW_HEADERFILE"/>
+    <inheritancegraph visible="yes"/>
+    <collaborationgraph visible="yes"/>
+    <detaileddescription visible="yes" title=""/>
+    <memberdecl>
+      <nestedclasses visible="yes" title=""/>
+      <publictypes visible="yes" title=""/>
+      <services visible="yes" title=""/>
+      <interfaces visible="yes" title=""/>
+      <publicslots visible="yes" title=""/>
+      <signals visible="yes" title=""/>
+      <publicmethods visible="yes" title=""/>
+      <publicstaticmethods visible="yes" title=""/>
+      <publicattributes visible="yes" title=""/>
+      <publicstaticattributes visible="yes" title=""/>
+      <protectedtypes visible="yes" title=""/>
+      <protectedslots visible="yes" title=""/>
+      <protectedmethods visible="yes" title=""/>
+      <protectedstaticmethods visible="yes" title=""/>
+      <protectedattributes visible="yes" title=""/>
+      <protectedstaticattributes visible="yes" title=""/>
+      <packagetypes visible="yes" title=""/>
+      <packagemethods visible="yes" title=""/>
+      <packagestaticmethods visible="yes" title=""/>
+      <packageattributes visible="yes" title=""/>
+      <packagestaticattributes visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+      <events visible="yes" title=""/>
+      <privatetypes visible="yes" title=""/>
+      <privateslots visible="yes" title=""/>
+      <privatemethods visible="yes" title=""/>
+      <privatestaticmethods visible="yes" title=""/>
+      <privateattributes visible="yes" title=""/>
+      <privatestaticattributes visible="yes" title=""/>
+      <friends visible="yes" title=""/>
+      <related visible="yes" title="" subtitle=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <memberdef>
+      <inlineclasses visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <services visible="yes" title=""/>
+      <interfaces visible="yes" title=""/>
+      <constructors visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <related visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+      <events visible="yes" title=""/>
+    </memberdef>
+    <allmemberslink visible="yes"/>
+    <usedfiles visible="$SHOW_USED_FILES"/>
+    <authorsection visible="yes"/>
+  </class>
+
+  <!-- Layout definition for a namespace page -->
+  <namespace>
+    <briefdescription visible="yes"/>
+    <memberdecl>
+      <nestednamespaces visible="yes" title=""/>
+      <constantgroups visible="yes" title=""/>
+      <interfaces visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <concepts visible="yes" title=""/>
+      <structs visible="yes" title=""/>
+      <exceptions visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <sequences visible="yes" title=""/>
+      <dictionaries visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+      <membergroups visible="yes" visible="yes"/>
+    </memberdecl>
+    <detaileddescription visible="yes" title=""/>
+    <memberdef>
+      <inlineclasses visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <sequences visible="yes" title=""/>
+      <dictionaries visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+    </memberdef>
+    <authorsection visible="yes"/>
+  </namespace>
+
+  <!-- Layout definition for a concept page -->
+  <concept>
+    <briefdescription visible="yes"/>
+    <includes visible="$SHOW_HEADERFILE"/>
+    <definition visible="yes" title=""/>
+    <detaileddescription visible="yes" title=""/>
+    <authorsection visible="yes"/>
+  </concept>
+
+  <!-- Layout definition for a file page -->
+  <file>
+    <briefdescription visible="yes"/>
+    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <includegraph visible="yes"/>
+    <includedbygraph visible="yes"/>
+    <sourcelink visible="yes"/>
+    <memberdecl>
+      <interfaces visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <structs visible="yes" title=""/>
+      <exceptions visible="yes" title=""/>
+      <namespaces visible="yes" title=""/>
+      <concepts visible="yes" title=""/>
+      <constantgroups visible="yes" title=""/>
+      <defines visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <sequences visible="yes" title=""/>
+      <dictionaries visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+      <membergroups visible="yes" visible="yes"/>
+    </memberdecl>
+    <detaileddescription visible="yes" title=""/>
+    <memberdef>
+      <inlineclasses visible="yes" title=""/>
+      <defines visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <sequences visible="yes" title=""/>
+      <dictionaries visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+    </memberdef>
+    <authorsection/>
+  </file>
+
+  <!-- Layout definition for a group page -->
+  <group>
+    <briefdescription visible="yes"/>
+    <groupgraph visible="yes"/>
+    <memberdecl>
+      <nestedgroups visible="yes" title=""/>
+      <modules visible="yes" title=""/>
+      <dirs visible="yes" title=""/>
+      <files visible="yes" title=""/>
+      <namespaces visible="yes" title=""/>
+      <concepts visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <defines visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <sequences visible="yes" title=""/>
+      <dictionaries visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <enumvalues visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <signals visible="yes" title=""/>
+      <publicslots visible="yes" title=""/>
+      <protectedslots visible="yes" title=""/>
+      <privateslots visible="yes" title=""/>
+      <events visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+      <friends visible="yes" title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <detaileddescription visible="yes" title=""/>
+    <memberdef>
+      <pagedocs/>
+      <inlineclasses visible="yes" title=""/>
+      <defines visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <sequences visible="yes" title=""/>
+      <dictionaries visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <enumvalues visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <signals visible="yes" title=""/>
+      <publicslots visible="yes" title=""/>
+      <protectedslots visible="yes" title=""/>
+      <privateslots visible="yes" title=""/>
+      <events visible="yes" title=""/>
+      <properties visible="yes" title=""/>
+      <friends visible="yes" title=""/>
+    </memberdef>
+    <authorsection visible="yes"/>
+  </group>
+
+  <!-- Layout definition for a C++20 module page -->
+  <module>
+    <briefdescription visible="yes"/>
+    <exportedmodules visible="yes"/>
+    <memberdecl>
+      <concepts visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <enums visible="yes" title=""/>
+      <typedefs visible="yes" title=""/>
+      <functions visible="yes" title=""/>
+      <variables visible="yes" title=""/>
+      <membergroups visible="yes" title=""/>
+    </memberdecl>
+    <detaileddescription visible="yes" title=""/>
+    <memberdecl>
+      <files visible="yes"/>
+    </memberdecl>
+  </module>
+
+  <!-- Layout definition for a directory page -->
+  <directory>
+    <briefdescription visible="yes"/>
+    <directorygraph visible="yes"/>
+    <memberdecl>
+      <dirs visible="yes"/>
+      <files visible="yes"/>
+    </memberdecl>
+    <detaileddescription visible="yes" title=""/>
+  </directory>
+</doxygenlayout>


### PR DESCRIPTION
## Description / 説明

Improve Doxygen documentation generation with configuration upgrades, custom page layout, and updated build requirements.

- Customize page layout with DoxygenLayout.xml: hide unused tabs, reorder navigation, move detailed description before member declarations
- Upgrade Doxygen configuration to 1.16: enable treeview navigation, dark/light auto theme, copy clipboard, documentation warnings, GraphViz support, parallel build
- Add GraphViz and Doxygen version requirements to build documentation

## Type of Change / 変更の種類

- [x] Documentation update / ドキュメントの更新

## Checklist / チェックリスト

- [x] My code follows the style guidelines of this project / コードはこのプロジェクトのスタイルガイドラインに従っています
- [x] I have performed a self-review of my own code / 自分のコードのセルフレビューを行いました
- [x] I have made corresponding changes to the documentation / ドキュメントに対応する変更を加えました
- [x] My changes generate no new warnings / 変更によって新しい警告が発生していません

## Additional Notes / 追加メモ

### Changed files
- `doxygen/DoxygenLayout.xml` — Custom layout file for navigation and page section ordering
- `doxygen/Doxyfile.in` — Doxygen configuration with new settings for 1.16
- `doxygen/DevToolsDocs.cmake` — Layout file copy and GraphViz auto-detection
- `CMakeLists.txt` — Require Doxygen 1.16+
- `BUILD.md` / `docs/ja/BUILD.md` — Add Doxygen and GraphViz version requirements
- `docs/api/README.md` / `docs/getting-started/installation.md` — Add version requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * APIドキュメント生成にはDoxygen 1.16以上が必要になりました。
  * GraphVizはオプションで、クラス図や依存関係図の生成に対応しました。GraphVizがない場合でも、図表なしでドキュメント生成は可能です。
  * ドキュメントのナビゲーションとレイアウトが改善され、より見やすいHTMLドキュメントが生成されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->