### PR TITLE
ci: skip CodeQL analysis on Dependabot PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ jobs:
   analyze-actions:
     name: Analyze GitHub Actions
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout repository
@@ -34,6 +35,7 @@ jobs:
   analyze-cpp:
     name: Analyze C++
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 概要

Dependabot PRでCodeQL解析が不要に実行される問題を修正。

## 関連Issue

- https://github.com/LotusAndCompany/devtools/actions/runs/24485431653?pr=33

## 変更の種類

- [x] `chore` - 設定・依存関係・ビルド

## 変更内容

- `analyze-actions` ジョブに `if: github.actor != 'dependabot[bot]'` を追加
- `analyze-cpp` ジョブに `if: github.actor != 'dependabot[bot]'` を追加

## テスト内容

- 次回のDependabot PRでCodeQLジョブがスキップされることを確認
- 通常のPRではCodeQLが引き続き実行されることを確認

## チェックリスト

- [x] 既存の機能に影響がないことを確認した