### PR TITLE
ci: skip clang-tidy job for dependabot PRs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -71,6 +71,7 @@ jobs:
   clang-tidy:
     name: Static Analysis
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
 


### PR DESCRIPTION
## Description / 説明

Dependabot が GitHub Actions の依存を更新する PR では C++ ソースに変更が入らないため、`Code Quality` ワークフローの `clang-tidy` ジョブ（Static Analysis）は意味がなく、CI 時間と Qt/vcpkg のセットアップコストだけを消費しています。

既に `.github/workflows/codeql.yml` の `analyze-actions` / `analyze-cpp` ジョブが採用しているのと同じ条件 `if: github.actor != 'dependabot[bot]'` を `clang-tidy` ジョブに付け、Dependabot PR でのみスキップします。

- 影響範囲: Dependabot 起因の PR でのみ `clang-tidy` ジョブが skip される。
- 人手の PR では従来どおり実行される。
- `clang-format` ジョブと `format-suggestion` ジョブは軽量なため対象外。

Fixes # (issue)

## Type of Change / 変更の種類

- [x] Other (please describe) / その他（説明してください）: CI ワークフローの調整

## Checklist / チェックリスト

- [x] My code follows the style guidelines of this project / コードはこのプロジェクトのスタイルガイドラインに従っています
- [x] I have performed a self-review of my own code / 自分のコードのセルフレビューを行いました
- [ ] I have commented my code, particularly in hard-to-understand areas / 特に理解しにくい部分にコメントを追加しました
- [ ] I have made corresponding changes to the documentation / ドキュメントに対応する変更を加えました
- [x] My changes generate no new warnings / 変更によって新しい警告が発生していません
- [ ] I have added tests that prove my fix is effective or that my feature works / 修正が有効であること、または機能が動作することを証明するテストを追加しました
- [ ] New and existing unit tests pass locally with my changes / 変更により新規および既存のユニットテストがローカルでパスします

## Additional Notes / 追加メモ

References:
- `.github/workflows/code-quality.yml:71` (今回の変更対象)
- `.github/workflows/codeql.yml:38` (既に同じ条件を使用している前例)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **保守（Chores）**
  * 継続的インテグレーション（CI）ワークフローの条件付き実行を最適化しました。特定の自動化されたコントリビューションに対して静的解析ステップをスキップするよう調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->