### PR TITLE
fix(phrase_generation): improve save button position in phrase generation UI

### DIFF
--- a/gui/phrase_generation/phrase_generation.cpp
+++ b/gui/phrase_generation/phrase_generation.cpp
@@ -24,39 +24,14 @@ phraseGeneration::phraseGeneration(QWidget *parent) : QWidget(parent), ui(new Ui
     connect(ui->titleTreeWidget, &QTreeWidget::itemClicked, this,
             &phraseGeneration::handleTitleTreeWidgetItemClick);
 
-    auto *gridLayout = new QGridLayout(this);
-
-    gridLayout->addWidget(ui->templateTitle, 0, 0, 1, 2);
-    gridLayout->addWidget(ui->deleteButton, 0, 2, 1, 1);
-    gridLayout->addWidget(ui->copyButton, 0, 3, 1, 1);
-    gridLayout->addWidget(ui->addButton, 0, 4, 1, 1);
-    gridLayout->addWidget(ui->toggleTreeButton, 0, 6, 1, 1);
-    gridLayout->addWidget(ui->line, 1, 0, 1, 7);
-    gridLayout->addWidget(ui->templateText, 2, 0, 7, 7);
-    gridLayout->addWidget(ui->titleTreeWidget, 2, 5, 7, 2);
-    gridLayout->addWidget(ui->saveButton, 8, 5, 1, 1);
-
-    // ストレッチ係数を設定
-    gridLayout->setColumnStretch(0, 3); // 左側に多くスペースを割り当てる
-    gridLayout->setColumnStretch(5, 1); // titleTreeWidget の列
-
     this->setMinimumSize(300, 200);
-
-    this->setLayout(gridLayout);
 
     ui->titleTreeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     ui->titleTreeWidget->header()->setSectionResizeMode(1, QHeaderView::Fixed);
-    ui->titleTreeWidget->setColumnWidth(1, 40);
+    ui->titleTreeWidget->setColumnWidth(1, 60);
 
-    // ダークモードかライトモードかを判定してQTreeWidgetのリストの要素のボーダーカラーを決める
-    QPalette const palette = this->palette();
-    QColor const baseColor = palette.color(QPalette::Base);
-    QColor const borderColor = (baseColor.lightness() > 128) ? Qt::black : Qt::white;
-    ui->titleTreeWidget->setStyleSheet(
-        QString("QTreeWidget::item { border-bottom: 1px solid %1; }"
-                "QTreeWidget::item:selected { background-color: #0078d7; color: "
-                "#ffffff; }")
-            .arg(borderColor.name()));
+    // スタイル適用
+    updateTreeStyle();
 
     ui->titleTreeWidget->setVisible(false);
     loadTitles();
@@ -65,6 +40,19 @@ phraseGeneration::phraseGeneration(QWidget *parent) : QWidget(parent), ui(new Ui
 phraseGeneration::~phraseGeneration()
 {
     delete ui;
+}
+
+// ダークモードかライトモードかを判定してQTreeWidgetのリストの要素のボーダーカラーを決める
+void phraseGeneration::updateTreeStyle()
+{
+    QPalette const palette = this->palette();
+    QColor const baseColor = palette.color(QPalette::Base);
+    QColor const borderColor = (baseColor.lightness() > 128) ? Qt::black : Qt::white;
+
+    ui->titleTreeWidget->setStyleSheet(
+        QString("QTreeWidget::item { border-bottom: 1px solid %1; padding: 5px; }"
+                "QTreeWidget::item:selected { background-color: #0078d7; color: #ffffff; }")
+            .arg(borderColor.name()));
 }
 
 // カラーテーマ変更時に走る処理
@@ -209,27 +197,13 @@ void phraseGeneration::deleteContent(const QString &filename)
 
 void phraseGeneration::handleToggleTreeButtonClick()
 {
-    bool const isVisible = ui->titleTreeWidget->isVisible();
-    ui->titleTreeWidget->setVisible(!isVisible);
+    bool const nextVisible = !ui->titleTreeWidget->isVisible();
+    ui->titleTreeWidget->setVisible(nextVisible);
 
-    auto *grid = qobject_cast<QGridLayout *>(this->layout());
-    if (grid == nullptr) {
-        return;
-    }
-
-    // ボタンのテキストを切り替える
-    if (ui->titleTreeWidget->isVisible()) {
+    if (nextVisible) {
         ui->toggleTreeButton->setIcon(QIcon::fromTheme("close"));
-        this->layout()->removeWidget(ui->templateText);
-        grid->addWidget(ui->templateText, 2, 0, 7, 5);
-        this->layout()->removeWidget(ui->saveButton);
-        grid->addWidget(ui->saveButton, 8, 4, 1, 1);
     } else {
         ui->toggleTreeButton->setIcon(QIcon::fromTheme("menu"));
-        this->layout()->removeWidget(ui->templateText);
-        grid->addWidget(ui->templateText, 2, 0, 7, 7);
-        this->layout()->removeWidget(ui->saveButton);
-        grid->addWidget(ui->saveButton, 8, 5, 1, 1);
     }
 }
 

--- a/gui/phrase_generation/phrase_generation.h
+++ b/gui/phrase_generation/phrase_generation.h
@@ -36,6 +36,7 @@ private slots:
 
 private:
     Ui::phraseGeneration *ui;
+    void updateTreeStyle();
     void loadTitles();
     static QString loadContent(const QString &filename, QString *title = nullptr);
     static void saveContent(const QString &title, const QString &content);

--- a/gui/phrase_generation/phrase_generation.ui
+++ b/gui/phrase_generation/phrase_generation.ui
@@ -19,249 +19,223 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="Line" name="line">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>40</y>
-     <width>991</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="saveButton">
-   <property name="geometry">
-    <rect>
-     <x>665</x>
-     <y>595</y>
-     <width>100</width>
-     <height>32</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <kerning>true</kerning>
-    </font>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">margin-right: 30px;
-margin-bottom: 15px;
-padding-top: 3px;
-padding-bottom: 3px;
-padding-left: 10px;
-padding-right: 10px;
-border-radius: 6px;
-background-color: rgb(175, 174, 177);</string>
-   </property>
-   <property name="text">
-    <string>Save</string>
-   </property>
-  </widget>
-  <widget class="QTreeWidget" name="titleTreeWidget">
-   <property name="geometry">
-    <rect>
-     <x>770</x>
-     <y>50</y>
-     <width>241</width>
-     <height>600</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="styleSheet">
-    <string notr="true"/>
-   </property>
-   <property name="headerHidden">
-    <bool>true</bool>
-   </property>
-   <property name="columnCount">
-    <number>2</number>
-   </property>
-   <column>
-    <property name="text">
-     <string notr="true">1</string>
-    </property>
-   </column>
-   <column>
-    <property name="text">
-     <string notr="true">2</string>
-    </property>
-   </column>
-  </widget>
-  <widget class="QPlainTextEdit" name="templateText">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>2</x>
-     <y>60</y>
-     <width>1011</width>
-     <height>571</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>20</pointsize>
-    </font>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">QPlainTextEdit {
-    padding: 0px 0px 5px 0px;
-}</string>
-   </property>
-   <property name="placeholderText">
-    <string>Text</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="addButton">
-   <property name="geometry">
-    <rect>
-     <x>289</x>
-     <y>0</y>
-     <width>110</width>
-     <height>52</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>30</pointsize>
-    </font>
-   </property>
-   <property name="text">
-    <string/>
-   </property>
-   <property name="icon">
-    <iconset theme="add"/>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="toggleTreeButton">
-   <property name="geometry">
-    <rect>
-     <x>413</x>
-     <y>3</y>
-     <width>102</width>
-     <height>45</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="font">
-    <font>
-     <family>Symbol</family>
-     <pointsize>27</pointsize>
-     <bold>true</bold>
-    </font>
-   </property>
-   <property name="text">
-    <string/>
-   </property>
-   <property name="icon">
-    <iconset theme="menu"/>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="deleteButton">
-   <property name="geometry">
-    <rect>
-     <x>130</x>
-     <y>10</y>
-     <width>69</width>
-     <height>32</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="text">
-    <string>Delete</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="copyButton">
-   <property name="geometry">
-    <rect>
-     <x>213</x>
-     <y>10</y>
-     <width>62</width>
-     <height>32</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="text">
-    <string>Copy</string>
-   </property>
-  </widget>
-  <widget class="QLineEdit" name="templateTitle">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>1</x>
-     <y>5</y>
-     <width>121</width>
-     <height>37</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>28</pointsize>
-    </font>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">QLineEdit {
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="templateTitle">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>28</pointsize>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QLineEdit {
     padding: 2px 0px 2px 2px;
 }</string>
-   </property>
-   <property name="placeholderText">
-    <string>Title</string>
-   </property>
-  </widget>
-  <zorder>addButton</zorder>
-  <zorder>toggleTreeButton</zorder>
-  <zorder>deleteButton</zorder>
-  <zorder>copyButton</zorder>
-  <zorder>templateTitle</zorder>
-  <zorder>templateText</zorder>
-  <zorder>line</zorder>
-  <zorder>saveButton</zorder>
-  <zorder>titleTreeWidget</zorder>
+       </property>
+       <property name="placeholderText">
+        <string>Title</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copyButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Copy</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="addButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>30</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset theme="add"/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="toggleTreeButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <family>Symbol</family>
+         <pointsize>27</pointsize>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset theme="menu"/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QPlainTextEdit" name="templateText">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>20</pointsize>
+          </font>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QPlainTextEdit {
+    padding: 0px 0px 5px 0px;
+}</string>
+         </property>
+         <property name="placeholderText">
+          <string>Text</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="titleTreeWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
+         <property name="columnCount">
+          <number>2</number>
+         </property>
+         <column>
+          <property name="text">
+           <string notr="true">1</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string notr="true">2</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="saveButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <kerning>true</kerning>
+          </font>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string>Save</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/gui/phrase_generation/phrase_generation.ui
+++ b/gui/phrase_generation/phrase_generation.ui
@@ -167,7 +167,7 @@
        <item>
         <widget class="QTreeWidget" name="titleTreeWidget">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/gui/phrase_generation/phrase_generation.ui
+++ b/gui/phrase_generation/phrase_generation.ui
@@ -82,7 +82,13 @@
         </font>
        </property>
        <property name="text">
-        <string/>
+        <string>追加</string>
+       </property>
+       <property name="toolTip">
+        <string>追加</string>
+       </property>
+       <property name="accessibleName">
+        <string>追加</string>
        </property>
        <property name="icon">
         <iconset theme="add"/>
@@ -118,7 +124,13 @@
         </font>
        </property>
        <property name="text">
-        <string/>
+        <string>ツリービュー切替</string>
+       </property>
+       <property name="toolTip">
+        <string>ツリービュー切替</string>
+       </property>
+       <property name="accessibleName">
+        <string>ツリービュー切替</string>
        </property>
        <property name="icon">
         <iconset theme="menu"/>

--- a/res/dev-tools_ja_JP.ts
+++ b/res/dev-tools_ja_JP.ts
@@ -1655,13 +1655,13 @@ Choose a tool from the side panel</source>
         <translation>SQLiteデータベースファイルを選択してください。</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+6"/>
+        <location line="+10"/>
+        <location line="+7"/>
         <source>Connection Failed</source>
         <translation>接続失敗</translation>
     </message>
     <message>
-        <location line="+64"/>
+        <location line="+65"/>
         <source>Refresh</source>
         <translation>更新</translation>
     </message>
@@ -1681,7 +1681,21 @@ Choose a tool from the side panel</source>
         <translation>フォーム</translation>
     </message>
     <message>
-        <location line="+210"/>
+        <location line="+65"/>
+        <location line="+3"/>
+        <location line="+3"/>
+        <source>追加</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+36"/>
+        <location line="+3"/>
+        <location line="+3"/>
+        <source>ツリービュー切替</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+109"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
@@ -1691,7 +1705,7 @@ Choose a tool from the side panel</source>
         <translation>テキスト</translation>
     </message>
     <message>
-        <location line="-122"/>
+        <location line="-134"/>
         <source>Title</source>
         <translation>タイトル</translation>
     </message>

--- a/res/dev-tools_ja_JP.ts
+++ b/res/dev-tools_ja_JP.ts
@@ -1688,12 +1688,12 @@ Choose a tool from the side panel</source>
     <message>
         <location line="-67"/>
         <source>Text</source>
-        <translation type="unfinished">テキスト</translation>
+        <translation>テキスト</translation>
     </message>
     <message>
         <location line="-122"/>
         <source>Title</source>
-        <translation type="unfinished">タイトル</translation>
+        <translation>タイトル</translation>
     </message>
     <message>
         <source>Enter title...</source>

--- a/res/dev-tools_ja_JP.ts
+++ b/res/dev-tools_ja_JP.ts
@@ -1681,17 +1681,17 @@ Choose a tool from the side panel</source>
         <translation>フォーム</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+210"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location line="+61"/>
+        <location line="-67"/>
         <source>Text</source>
         <translation type="unfinished">テキスト</translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="-122"/>
         <source>Title</source>
         <translation type="unfinished">タイトル</translation>
     </message>
@@ -1700,13 +1700,13 @@ Choose a tool from the side panel</source>
         <translation type="vanished">タイトルを入力...</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="+13"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../gui/phrase_generation/phrase_generation.cpp" line="+109"/>
+        <location line="+13"/>
+        <location filename="../gui/phrase_generation/phrase_generation.cpp" line="+97"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>


### PR DESCRIPTION
## Description / 説明

Adjust the position of the save button in the phrase generation screen for improved UI consistency and usability.

Fixes # (issue)

## Type of Change / 変更の種類

- [ ] Bug fix (non-breaking change which fixes an issue) / バグ修正（Issueを修正する非破壊的変更）
- [x] New feature (non-breaking change which adds functionality) / 新機能（機能を追加する非破壊的変更）
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) / 破壊的変更（既存の機能が期待どおりに動作しなくなる修正または機能）
- [ ] Documentation update / ドキュメントの更新
- [ ] Refactoring / リファクタリング
- [ ] Other (please describe) / その他（説明してください）

## Checklist / チェックリスト

- [x] My code follows the style guidelines of this project / コードはこのプロジェクトのスタイルガイドラインに従っています
- [x] I have performed a self-review of my own code / 自分のコードのセルフレビューを行いました
- [ ] I have commented my code, particularly in hard-to-understand areas / 特に理解しにくい部分にコメントを追加しました
- [ ] I have made corresponding changes to the documentation / ドキュメントに対応する変更を加えました
- [x] My changes generate no new warnings / 変更によって新しい警告が発生していません
- [ ] I have added tests that prove my fix is effective or that my feature works / 修正が有効であること、または機能が動作することを証明するテストを追加しました
- [x] New and existing unit tests pass locally with my changes / 変更により新規および既存のユニットテストがローカルでパスします

## Screenshots / スクリーンショット

N/A

## Additional Notes / 追加メモ

Minor UI adjustment only. No functional impact on business logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * フレーズ生成UIをレイアウト管理へ全面移行し、ウィジェットの絶対配置を削除して配置・サイズを安定化しました
  * ツールバーを一行にまとめ、操作ボタンの配置と文言（ツールチップ含む）を更新しました
  * ツリービューの列幅と余白を拡張して表示を改善し、スタイル処理を一元化、表示切替の挙動を簡素化しました
  * 保存ボタンのスタイル設定を初期化しました

* **Localization**
  * 日本語翻訳のメタ情報を更新し、複数の文字列を確定しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LotusAndCompany/devtools/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->