### PR TITLE
ci: add Doxygen HTML deployment via GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,95 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'core/**'
+      - 'gui/**'
+      - 'docs/**'
+      - 'doxygen/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  DOXYGEN_VERSION: '1.17.0'
+
+jobs:
+  build:
+    name: Build Doxygen HTML
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build graphviz
+
+      - name: Install Doxygen
+        env:
+          DOXYGEN_VERSION: ${{ env.DOXYGEN_VERSION }}
+        run: |
+          set -euxo pipefail
+          curl -fsSL "https://doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" \
+            | sudo tar -xz -C /opt
+          echo "/opt/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4
+        with:
+          version: '6.9.3'
+          host: 'linux'
+          target: 'desktop'
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7 # v11
+        with:
+          vcpkgGitCommitId: '10b7a178346f3f0abef60cecd5130e295afd8da4'
+
+      - name: Configure CMake
+        run: |
+          cmake -B build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Generate Doxygen HTML
+        run: cmake --build build --target DevTools_docs
+
+      - name: Verify HTML output
+        run: test -f build/doxygen/html/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: build/doxygen/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,6 +18,8 @@ concurrency:
 
 env:
   DOXYGEN_VERSION: '1.17.0'
+  # SHA256 of doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz; update together with DOXYGEN_VERSION
+  DOXYGEN_SHA256: '75419ef4f446fc1c24ef12514b574e66e898ee6f527c6ae2ad84f91a905823c2'
 
 jobs:
   build:
@@ -38,10 +40,15 @@ jobs:
       - name: Install Doxygen
         env:
           DOXYGEN_VERSION: ${{ env.DOXYGEN_VERSION }}
+          DOXYGEN_SHA256: ${{ env.DOXYGEN_SHA256 }}
         run: |
           set -euxo pipefail
+          TEMP_DIR=$(mktemp -d)
+          trap 'rm -rf "$TEMP_DIR"' EXIT
           curl -fsSL "https://doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" \
-            | sudo tar -xz -C /opt
+            -o "${TEMP_DIR}/doxygen.tar.gz"
+          echo "${DOXYGEN_SHA256}  ${TEMP_DIR}/doxygen.tar.gz" | sha256sum -c -
+          sudo tar -xz -C /opt -f "${TEMP_DIR}/doxygen.tar.gz"
           echo "/opt/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
 
       - name: Install Qt


### PR DESCRIPTION
## Summary

Closes #24

Issue #24 で提案されていたデプロイキー (`DOCS_DEPLOY_KEY`) を使った `devtools-docs` リポジトリへのクロスリポジトリ push をやめ、**`devtools` 自身の GitHub Pages** に Doxygen HTML を公開するワークフローを追加しました。

### シークレット最少化の観点

| 比較 | 元案 (cross-repo push) | 本PR (same-repo Pages) |
|---|---|---|
| 必要なシークレット | `DOCS_DEPLOY_KEY` (ed25519 秘密鍵) | **なし** (`GITHUB_TOKEN` のみ) |
| 鍵ローテーション運用 | 必要 | 不要 |
| 権限スコープ | 別リポジトリへの書き込み | 当リポジトリの Pages 公開のみ |
| 認証方式 | SSH デプロイキー | OIDC (`id-token: write`) + Pages 専用 token |

`docs/index.md` / `docs/api/README.md` のリンクは既に `https://LotusAndCompany.github.io/devtools/` を指しているため、URL 変更は不要です。

### ワークフロー構成

- トリガー: `main` への push (`core/**`, `gui/**`, `docs/**`, `doxygen/**`, `CMakeLists.txt`, 当ワークフロー) + `workflow_dispatch`
- ビルド: ubuntu-latest で Doxygen 1.17.0 (公式バイナリ) + Qt 6.9.3 + vcpkg を準備し、`cmake --build build --target DevTools_docs` を実行
- デプロイ: `actions/upload-pages-artifact` → `actions/deploy-pages`
- 全 action は commit SHA でピン留め (既存ワークフローの慣習に揃える)

## 事前セットアップ (リポジトリ管理者向け)

このPRをマージする前後で、リポジトリ Settings → Pages → **Source: GitHub Actions** に切り替える必要があります。`devtools-docs` リポジトリは、移行後はリダイレクトのみのリポジトリに縮小するか、アーカイブを検討してください。

## Test plan

- [x] PR マージ前: `Settings → Pages` の Source を **GitHub Actions** に変更済みであることを確認
- [ ] `workflow_dispatch` で手動実行し、`build` ジョブが Doxygen HTML を生成できることを確認
- [x] `deploy` ジョブが正常終了し、`https://lotusandcompany.github.io/devtools/` で API リファレンスが閲覧できることを確認
- [x] `core/`, `gui/`, `docs/`, `doxygen/`, `CMakeLists.txt` のいずれかを変更する次回 push でワークフローが自動起動することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **チョア**
  * GitHub Pages への自動ドキュメント公開を追加しました。main へのプッシュや手動トリガーで最新のドキュメントをビルドして公開します。
  * ビルドの検証・アーティファクト化を行い、デプロイ権限の設定とバージョン指定可能なドキュメント生成ツールの利用をサポートします。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LotusAndCompany/devtools/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->