### PR TITLE
chore(agent): add shared agent harness rules

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,54 @@
+# Shared AI Agent Harness
+
+This directory contains shared, tool-neutral rules for AI coding agents.
+
+`AGENTS.md` remains the repository-wide source of truth. Files in
+`.agents/rules/` add path-scoped rules that are useful for tools with a
+Claude Code-like rules system.
+
+## Rule Schema
+
+Rules use Markdown with a small front matter block:
+
+```yaml
+---
+paths:
+  - "**/*.cpp"
+  - "**/*.h"
+---
+```
+
+The `paths` list uses glob patterns and describes when the rule should apply.
+Tools that cannot activate rules by path should load these files as general
+context and still respect the path hints.
+
+## Adapter Policy
+
+- Claude Code: `.claude/rules/*.md` should be thin adapters that import the
+  matching shared rule.
+- Gemini CLI: `GEMINI.md` imports shared rules directly.
+- Codex: `AGENTS.md` points Codex to this directory; `.codex/rules/` remains
+  command-permission policy, not coding guidance.
+- CodeRabbit: `.coderabbit.yaml` path instructions should mirror these rules.
+
+When changing project guidance, update `AGENTS.md` first if the rule is global.
+Use `.agents/rules/` only for path-scoped or domain-specific guidance.
+
+## Sync
+
+Run this after editing `AGENTS.md` or `.agents/rules/*.md`:
+
+```bash
+scripts/sync-agent-rules.py
+```
+
+The script regenerates:
+
+- `.claude/rules/*.md`
+- the generated import block in `GEMINI.md`
+
+Run the full harness validation with:
+
+```bash
+scripts/check-agent-harness.sh
+```

--- a/.agents/rules/cmake.md
+++ b/.agents/rules/cmake.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "**/CMakeLists.txt"
+  - "**/*.cmake"
+---
+
+# CMake Rules
+
+- Declare dependencies explicitly with `add_dependencies()` when target build
+  order matters.
+- Prefer target-based CMake commands (`target_link_libraries`,
+  `target_include_directories`, `target_sources`) over global include/link
+  settings.
+- Add new static feature modules with `qt_add_library(...)` and register them
+  in `MODULE_LIST`.
+- Place business logic in `core/` and UI components in `gui/`.
+- Update `vcpkg.json` when adding vcpkg-managed packages.
+- Add tests in `tests/DevToolsTests.cmake` using `DevTools_add_test()`.
+- Qt AUTOMOC, AUTORCC, and AUTOUIC are enabled; do not add manual moc/uic/rcc
+  generation unless there is a specific build-system reason.

--- a/.agents/rules/cpp-style.md
+++ b/.agents/rules/cpp-style.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "**/*.cpp"
+  - "**/*.h"
+  - "**/*.hpp"
+---
+
+# C++ Style Rules
+
+- All C++ code must conform to `.clang-format` and `.clang-tidy`.
+- All files must conform to `.editorconfig`: LF line endings, final newline,
+  trimmed trailing whitespace except Markdown, and spaces for indentation.
+- Run `cmake --build build --target format` after editing C++ files.
+- Column limit is 100 characters.
+- Braces use Allman style for functions/classes/structs and K&R for control
+  statements.
+- Pointer/reference alignment is right-aligned: `int *ptr`, `int &ref`.
+- Include order is local, Qt, third-party, standard library, then system.
+- Classes, structs, and enums use `PascalCase`.
+- Functions use `camelCase`.
+- Variables and members use `snake_case`.
+- Constants and macros use `SCREAMING_SNAKE_CASE`.
+- Files use `snake_case`.
+- Keep functions under 100 lines and 50 statements where practical; split
+  complex logic before it becomes hard to review.
+- Keep business logic in `core/` free of Qt Widgets dependencies.
+- Use new-style Qt signal/slot syntax: `&Class::method`.
+- Set a Qt parent for `new`-allocated widgets, or use smart pointers for
+  non-QObject ownership.
+- Use Qt macros as-is: `Q_OBJECT`, `Q_PROPERTY`, `Q_SIGNALS`, `Q_SLOTS`, and
+  `emit`.
+- Pass `QString`, `QStringList`, `QVariant`, `QByteArray`, `QImage`, and
+  `QPixmap` by const reference unless moving or storing is intentional.
+- Wrap user-visible UI text with `tr()`.

--- a/.agents/rules/design-files.md
+++ b/.agents/rules/design-files.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "designs/screens/**/*.pen"
+  - "docs/development/design-files.md"
+---
+
+# Design File Rules
+
+UI design files live under `designs/screens/`, one file per screen or dialog
+group. Common chrome such as the sidebar and header is intentionally excluded
+from individual screen files.
+
+- Edit `.pen` files via the Pencil editor or the `pencil` MCP server only.
+- Never read, grep, or edit `.pen` files directly; they are encrypted.
+- One screen per PR keeps diffs reviewable and minimizes auto-merge risk.
+- There is no master or aggregate design file. Multi-screen changes should
+  touch each file separately.
+- `.pen` files are tracked as plain text, but encrypted payloads can corrupt
+  under text auto-merge. Keep edits localized and coordinate conflicts.
+- See `docs/development/design-files.md` for the full guide.

--- a/.agents/rules/docs.md
+++ b/.agents/rules/docs.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "**/*.md"
+---
+
+# Documentation Rules
+
+- Keep documentation accurate for a macOS 15.0+ Apple Silicon C++17/Qt6
+  desktop application.
+- Bilingual support exists for English and Japanese; Japanese files live under
+  `docs/ja/`.
+- When updating an English document, update the corresponding Japanese document
+  only if it already exists.
+- Do not create new Japanese mirror files unless explicitly requested.
+- Commit messages and PR titles for docs-only changes should use
+  `docs: <description>`.

--- a/.agents/rules/exec-plans.md
+++ b/.agents/rules/exec-plans.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "docs/exec-plans/**"
+---
+
+# Execution Plan Rules
+
+- Use execution plans for complex, multi-step, architectural, or long-running
+  agent tasks.
+- Keep active plans under `docs/exec-plans/active/`.
+- Move useful completed plans to `docs/exec-plans/completed/`.
+- Track durable follow-up work in `docs/exec-plans/tech-debt-tracker.md`.
+- Plans should include objective, scope, relevant rules/docs, implementation
+  steps, validation commands, decision log, and completion notes.
+- Keep plans concise and remove stale plans that no longer help future agents.

--- a/.agents/rules/generated-files.md
+++ b/.agents/rules/generated-files.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "build/**"
+  - "build-*/**"
+  - "CMakeFiles/**"
+  - "Testing/**"
+  - "vcpkg_installed/**"
+  - "res/**/*.qm"
+  - "app_info.autogen.cpp"
+  - "**/moc_*.cpp"
+  - "**/moc_*.h"
+  - "**/ui_*.h"
+  - "**/qrc_*.cpp"
+---
+
+# Generated Files Rules
+
+- Do not edit build outputs, Qt-generated files, or compiled translation files
+  directly.
+- Do not commit normal build artifacts from `build/`, `build-*`, `CMakeFiles/`,
+  `Testing/`, or `vcpkg_installed/`.
+- Update `.ts` translation sources only through the explicit translation update
+  workflow when translatable strings change.
+- Treat bundled third-party code such as `core/qr_tool/qrcodegen.*` as vendor
+  code; avoid style-only edits there.

--- a/.agents/rules/git-workflow.md
+++ b/.agents/rules/git-workflow.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "**/*"
+---
+
+# Git Workflow Rules
+
+- Use Conventional Commits: `<type>(<scope>): <subject>`.
+- Keep subjects lowercase, present tense, and imperative.
+- Allowed commit types are `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
+  `chore`, `build`, `ci`, and `perf`.
+- Branch names should use `<type>/<description>` with lowercase, hyphenated
+  descriptions. Allowed prefixes include `feature/`, `fix/`, `doc/`,
+  `refactor/`, and `hotfix/`.
+- PR titles must follow Conventional Commits and use lowercase subject text.
+- Follow `.github/PULL_REQUEST_TEMPLATE.md` for pull request bodies.
+- release-please determines versions from Conventional Commits.
+- Do not manually edit release-please managed version files or `CHANGELOG.md`
+  unless the task is explicitly release-related.
+- Do not include AI tool author attribution in commits, PRs, or issues.

--- a/.agents/rules/i18n.md
+++ b/.agents/rules/i18n.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "**/*.cpp"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.ui"
+  - "res/**/*.ts"
+  - "**/CMakeLists.txt"
+  - "**/*.cmake"
+---
+
+# i18n Rules
+
+- Qt translation support is English/Japanese.
+- English is the source language; Japanese translations are tracked in
+  `res/dev-tools_ja_JP.ts`.
+- Wrap all user-visible UI text with `tr()`.
+- Normal builds generate `.qm` files but must not update `.ts` files.
+- Update `.ts` only when translatable strings change:
+
+```bash
+cmake --build build --target update_devtools_translations
+```
+
+- Compile translations with:
+
+```bash
+cmake --build build --target release_devtools_translations
+```

--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "**/*"
+---
+
+# Project Rules
+
+DevTools is a macOS desktop application built with C++17 and Qt6 Widgets.
+
+## Build
+
+```bash
+# Configure with CMake (vcpkg toolchain)
+cd build && cmake .. -DCMAKE_TOOLCHAIN_FILE=/opt/homebrew/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Build
+make -j8
+
+# Enable and run unit tests
+cmake .. -DENABLE_UNIT_TEST=ON
+ctest
+
+# Format check
+cmake --build . --target format-check
+
+# Static analysis
+cmake --build . --target lint
+```
+
+## Architecture
+
+- `core/`: business logic. Do not introduce Qt Widgets dependencies here.
+  QtCore, QtGui, QtSql, QtNetwork are allowed.
+- `gui/`: Qt6 Widgets UI layer.
+- `tests/`: Google Test based unit tests.
+- Each feature is a static library module.
+
+## Dependencies
+
+- vcpkg: toml11, yaml-cpp. See `vcpkg.json`.
+- Qt6: Core, Widgets, LinguistTools, Sql, Network.
+- Bundled vendor code: qrcodegen under `core/qr_tool/qrcodegen/`.
+
+## Pre-commit Hooks
+
+Setup:
+
+```bash
+pre-commit install --install-hooks -t pre-commit -t commit-msg -t pre-push
+```
+
+Hooks run clang-format, trailing-whitespace, EOF fixer, large file check,
+commit message validation, and pre-push build verification.
+
+## Agent Harness
+
+- `AGENTS.md` is the bootstrap instruction file for all AI coding tools.
+- Path-scoped, Claude Code-like rules live in `.agents/rules/`.
+- Tool-specific configs should import or mirror `.agents/rules/` instead of
+  duplicating guidance.
+- After editing `AGENTS.md` or `.agents/rules/*.md`, run
+  `scripts/sync-agent-rules.py` to regenerate tool-specific adapters.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "tests/**"
+  - "**/test_*.cpp"
+  - "**/test_*.h"
+---
+
+# Testing Rules
+
+- Tests are disabled by default; configure with `cmake .. -DENABLE_UNIT_TEST=ON`
+  before running them.
+- Register new tests in `tests/DevToolsTests.cmake` with `DevTools_add_test()`.
+- Prefer `ctest --output-on-failure` when diagnosing failures.
+- Keep core tests focused on business logic and avoid GUI dependencies unless
+  the component under test is explicitly in `gui/`.
+- Use `ASSERT_*` only when continuing would make the rest of the test invalid;
+  otherwise prefer `EXPECT_*`.

--- a/.claude/rules/cmake.md
+++ b/.claude/rules/cmake.md
@@ -6,7 +6,4 @@ paths:
 
 # CMake Rules
 
-- Declare dependencies explicitly with `add_dependencies()`
-- Update `vcpkg.json` when adding vcpkg packages
-- Add tests in `tests/DevToolsTests.cmake` using `DevTools_add_test()`
-- Qt AUTOMOC, AUTORCC, AUTOUIC are enabled (no manual setup needed)
+@../../.agents/rules/cmake.md

--- a/.claude/rules/cpp-style.md
+++ b/.claude/rules/cpp-style.md
@@ -7,6 +7,4 @@ paths:
 
 # C++ Style Rules
 
-- Run `cmake --build build --target format` after editing to apply formatting
-- Keep functions under 100 lines / 50 statements
-- Pass QString, QStringList, QVariant, QByteArray, QImage, QPixmap by const reference
+@../../.agents/rules/cpp-style.md

--- a/.claude/rules/design-files.md
+++ b/.claude/rules/design-files.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "designs/screens/**/*.pen"
+  - "docs/development/design-files.md"
+---
+
+# Design File Rules
+
+@../../.agents/rules/design-files.md

--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -5,7 +5,4 @@ paths:
 
 # Documentation Rules
 
-- Bilingual support: English and Japanese (`docs/ja/` for Japanese version)
-- When updating an English document, update the corresponding Japanese document only if it already exists
-- Do not create new Japanese mirror files unless explicitly requested
-- Commit messages / PR titles follow Conventional Commits: `docs: <description>`
+@../../.agents/rules/docs.md

--- a/.claude/rules/exec-plans.md
+++ b/.claude/rules/exec-plans.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "docs/exec-plans/**"
+---
+
+# Execution Plan Rules
+
+@../../.agents/rules/exec-plans.md

--- a/.claude/rules/generated-files.md
+++ b/.claude/rules/generated-files.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "build/**"
+  - "build-*/**"
+  - "CMakeFiles/**"
+  - "Testing/**"
+  - "vcpkg_installed/**"
+  - "res/**/*.qm"
+  - "app_info.autogen.cpp"
+  - "**/moc_*.cpp"
+  - "**/moc_*.h"
+  - "**/ui_*.h"
+  - "**/qrc_*.cpp"
+---
+
+# Generated Files Rules
+
+@../../.agents/rules/generated-files.md

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "**/*"
+---
+
+# Git Workflow Rules
+
+@../../.agents/rules/git-workflow.md

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "**/*.cpp"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.ui"
+  - "res/**/*.ts"
+  - "**/CMakeLists.txt"
+  - "**/*.cmake"
+---
+
+# i18n Rules
+
+@../../.agents/rules/i18n.md

--- a/.claude/rules/project.md
+++ b/.claude/rules/project.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "**/*"
+---
+
+# Project Rules
+
+@../../.agents/rules/project.md

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "tests/**"
+  - "**/test_*.cpp"
+  - "**/test_*.h"
+---
+
+# Testing Rules
+
+@../../.agents/rules/testing.md

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -123,6 +123,17 @@ reviews:
         GitHub Actions のセキュリティ（secrets の適切な使用、permissions の最小権限）、
         キャッシュ戦略に注意してレビューしてください。
 
+    - path: ".agents/rules/**/*.md"
+      instructions: >
+        共有 AI agent rules の正本です。path frontmatter と本文が対応しているか、
+        AGENTS.md と重複しすぎていないか、変更後に scripts/sync-agent-rules.py で
+        各ツール adapter が再生成されているか確認してください。
+
+    - path: ".claude/rules/**/*.md"
+      instructions: >
+        Claude Code 用の thin adapter です。本文を直接重複させず、
+        対応する .agents/rules/*.md を参照しているか確認してください。
+
     - path: "res/**/*.ts"
       instructions: >
         Qt Linguist の翻訳ファイルです。

--- a/.github/workflows/agent-harness.yml
+++ b/.github/workflows/agent-harness.yml
@@ -1,0 +1,46 @@
+name: Agent Harness
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'AGENTS.md'
+      - '.agents/**'
+      - '.claude/rules/**'
+      - 'GEMINI.md'
+      - 'docs/development/ai-agent-harness.md'
+      - 'docs/exec-plans/**'
+      - 'scripts/sync-agent-rules.py'
+      - 'scripts/check-agent-harness.sh'
+      - '.github/workflows/agent-harness.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'AGENTS.md'
+      - '.agents/**'
+      - '.claude/rules/**'
+      - 'GEMINI.md'
+      - 'docs/development/ai-agent-harness.md'
+      - 'docs/exec-plans/**'
+      - 'scripts/sync-agent-rules.py'
+      - 'scripts/check-agent-harness.sh'
+      - '.github/workflows/agent-harness.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check generated agent adapters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run agent harness check
+        run: scripts/check-agent-harness.sh

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ Thumbs.db
 .qtc_clangd/*
 build/*
 
+# Tracked AI agent harness files
+!.claude/
+.claude/*
+!.claude/rules/
+.claude/rules/*
+!.claude/rules/*.md
+
 # qtcreator generated files
 *.pro.user*
 CMakeLists.txt.user*
@@ -68,6 +75,7 @@ CMakeLists.txt.user*
 
 # Python byte code
 *.pyc
+__pycache__/
 
 # Binaries
 # --------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,10 +75,26 @@ repos:
         name: check-merge-conflict
 
   # ===========================================================================
-  # CMake build verification (pre-push)
+  # Local project hooks
   # ===========================================================================
   - repo: local
     hooks:
+      - id: sync-agent-rules
+        name: sync-agent-rules
+        entry: scripts/sync-agent-rules.py
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        files: |
+          (?x)^(
+            AGENTS\.md|
+            GEMINI\.md|
+            \.agents/README\.md|
+            \.agents/rules/.*\.md|
+            \.claude/rules/.*\.md|
+            scripts/sync-agent-rules\.py
+          )$
+
       - id: cmake-build
         name: cmake-build (pre-push)
         entry: bash scripts/pre-push-build.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,120 +1,39 @@
-# DevTools - AI Agent Guidelines
+# DevTools - AI Agent Bootstrap
 
-macOS desktop application built with C++17 and Qt6, providing integrated developer utilities.
+DevTools is a macOS desktop application built with C++17 and Qt6 Widgets.
 
-## Build
+This file is intentionally short. Detailed, path-scoped guidance lives in
+`.agents/rules/` and is synchronized into tool-specific adapters.
+
+## How to Use Rules
+
+- Always read this file first.
+- For implementation details, consult every `.agents/rules/*.md` file whose
+  `paths` front matter matches the files you will inspect or edit.
+- Rules with `paths: ["**/*"]` apply globally.
+- After editing `AGENTS.md` or `.agents/rules/*.md`, run:
 
 ```bash
-# Configure with CMake (vcpkg toolchain)
-cd build && cmake .. -DCMAKE_TOOLCHAIN_FILE=/opt/homebrew/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-
-# Build
-make -j8
-
-# Enable and run unit tests
-cmake .. -DENABLE_UNIT_TEST=ON
-ctest
-
-# Format check
-cmake --build . --target format-check
-
-# Static analysis
-cmake --build . --target lint
+scripts/sync-agent-rules.py
 ```
 
-## Code Formatting
+## Rule Index
 
-- All C++ code MUST conform to `.clang-format` (Google base + Qt adaptations)
-- All files MUST conform to `.editorconfig` rules:
-  - Files MUST end with a newline (`insert_final_newline = true`)
-  - Use LF line endings
-  - Trim trailing whitespace (except Markdown files, per `.editorconfig`)
-  - Indent with spaces (4 for C++, 2 for XML/Qt UI files)
-- Column limit: 100 characters
-- Braces: Allman style for functions/classes/structs, K&R for control statements
-- Pointer/reference alignment: right-aligned (`int *ptr`, `int &ref`)
-- Include order: local → Qt → third-party → standard library → system
-- See `.clang-format` and `.clang-tidy` for full details
+- `.agents/rules/project.md`: build, architecture, dependencies, hooks, harness
+- `.agents/rules/cpp-style.md`: C++/Qt style, formatting, naming
+- `.agents/rules/cmake.md`: CMake modules, dependencies, test registration
+- `.agents/rules/testing.md`: Google Test and CTest rules
+- `.agents/rules/i18n.md`: Qt translation workflow
+- `.agents/rules/docs.md`: English/Japanese documentation rules
+- `.agents/rules/exec-plans.md`: execution plan and tech-debt tracker rules
+- `.agents/rules/design-files.md`: Pencil `.pen` design file handling
+- `.agents/rules/generated-files.md`: generated artifacts and vendor files
+- `.agents/rules/git-workflow.md`: branches, commits, PRs, release-please
 
-## Naming Conventions
+## Critical Guardrails
 
-- Classes/Structs/Enums: `PascalCase`
-- Functions: `camelCase`
-- Variables/Members: `snake_case`
-- Constants/Macros: `SCREAMING_SNAKE_CASE`
-- Files: `snake_case`
-
-## Architecture
-
-- `core/`: business logic (no Qt Widgets dependency; QtCore, QtGui, QtSql, QtNetwork allowed)
-- `gui/`: Qt6 Widgets UI layer
-- `tests/`: Google Test based unit tests
-- Each feature is a static library module
-
-### Adding a New Module
-
-1. Define `qt_add_library(${PROJECT_NAME}_module_name STATIC ...)` in `CMakeLists.txt`
-2. Add to `MODULE_LIST`
-3. Place business logic in `core/`, UI components in `gui/`
-
-## Qt Conventions
-
-- Use new signal/slot syntax: `&Class::method`
-- Set parent for `new`-allocated widgets (Qt parent-child ownership)
-- Wrap UI text with `tr()` for i18n
-- Qt macros (Q_OBJECT, Q_PROPERTY, Q_SIGNALS, Q_SLOTS, emit) are used as-is
-
-## Git Workflow
-
-### Conventional Commits
-
-```
-<type>(<scope>): <subject>
-```
-
-type: feat, fix, docs, style, refactor, test, chore, build, ci, perf
-
-- Subject starts lowercase, use present tense imperative mood
-- release-please determines version automatically based on type
-
-### Branch Naming
-
-`<type>/<description>` (lowercase, hyphen-separated):
-- feature/, fix/, doc/, refactor/, hotfix/
-- With issue number: `feature/123-description`
-
-### Pull Requests
-
-- PR title must follow Conventional Commits format (validated by CI)
-- Follow `.github/PULL_REQUEST_TEMPLATE.md`
-
-## i18n
-
-- Qt translation support for English/Japanese. English is the source language; Japanese
-  translations are tracked in `res/dev-tools_ja_JP.ts`
-- Wrap all UI text with `tr()`
-- Normal builds generate `.qm` files but must not update `.ts` files
-- Update `.ts` only when translatable strings change:
-  `cmake --build build --target update_devtools_translations`
-
-## Dependencies
-
-- vcpkg: toml11, yaml-cpp (see `vcpkg.json`)
-- Qt6: Core, Widgets, LinguistTools, Sql, Network
-- Bundled: qrcodegen (`core/qr_tool/qrcodegen/`)
-
-## Pre-commit Hooks
-
-Setup: `pre-commit install --install-hooks -t pre-commit -t commit-msg -t pre-push`
-
-Runs: clang-format, trailing-whitespace, EOF fixer, large file check, commit-msg validation, pre-push build.
-
-## Design Files (Pencil `.pen`)
-
-UI design files live under `designs/screens/`, one file per screen or dialog group. Common chrome (sidebar, header) is intentionally excluded from individual screen files.
-
-- Edit `.pen` files via the Pencil editor or the `pencil` MCP server (`open_document` → `batch_get` / `batch_design`). **Never `Read` or `grep` `.pen` files directly** — they are encrypted.
-- One screen per PR keeps diffs reviewable and minimizes auto-merge risk.
-- No master/aggregate file. Multi-screen changes touch each file separately.
-- `.pen` files are tracked as plain text (no `binary` / `merge=binary` attribute). Encrypted payloads can corrupt under text auto-merge — keep edits localized and coordinate with the team.
-- See `docs/development/design-files.md` for the full guide.
+- Do not edit generated build outputs, Qt-generated files, compiled
+  translations, or bundled vendor code directly.
+- Do not read, grep, or edit Pencil `.pen` files directly; use the Pencil editor
+  or `pencil` MCP server.
+- Do not include AI tool author attribution in commits, PRs, or issues.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,6 +2,24 @@
 
 @AGENTS.md
 
+## Shared Path-Scoped Rules
+
+Load these shared rule files as additional project context. The `paths` front
+matter in each file describes when the rule applies.
+
+<!-- BEGIN GENERATED AGENT RULE IMPORTS -->
+@.agents/rules/cmake.md
+@.agents/rules/cpp-style.md
+@.agents/rules/design-files.md
+@.agents/rules/docs.md
+@.agents/rules/exec-plans.md
+@.agents/rules/generated-files.md
+@.agents/rules/git-workflow.md
+@.agents/rules/i18n.md
+@.agents/rules/project.md
+@.agents/rules/testing.md
+<!-- END GENERATED AGENT RULE IMPORTS -->
+
 ## Author Attribution
 
 IMPORTANT: Do not include Gemini CLI author information in commits, PRs, or Issues.

--- a/docs/development/ai-agent-harness.md
+++ b/docs/development/ai-agent-harness.md
@@ -1,48 +1,128 @@
 # AI Agent Harness
 
-This document describes the cross-tool AI agent configuration used in this project. Multiple AI coding assistants share a single source of truth while retaining tool-specific settings where needed.
+This document describes the cross-tool AI agent configuration used in this project. Multiple AI coding assistants share global and path-scoped guidance while retaining tool-specific settings where needed.
 
 ## Overview
 
 AI coding tools (Claude Code, Gemini CLI, OpenAI Codex, CodeRabbit, etc.) each have their own configuration format. Rather than maintaining duplicate guidelines in every tool's config, this project uses a layered architecture:
 
-1. **AGENTS.md** — shared guidelines that all tools can read
-2. **Tool-specific configs** — import or reference AGENTS.md, adding only tool-unique settings
+1. **AGENTS.md** — shared global guidelines that all tools can read
+2. **.agents/rules/** — shared path-scoped rules with a Claude Code-like shape
+3. **Tool-specific configs** — import or reference shared files, adding only tool-unique settings
 
-This means a change to AGENTS.md immediately benefits every tool.
+This means a global change to AGENTS.md, or a path-scoped change in `.agents/rules/`, can benefit every configured tool after running `scripts/sync-agent-rules.py`.
 
 ## Architecture
 
 ```text
-AGENTS.md  (single source of truth)
+AGENTS.md  (global source of truth)
+    │
+    ├── .agents/rules/ ........ shared path-scoped rules
+    │   ├── cmake.md
+    │   ├── cpp-style.md
+    │   ├── design-files.md
+    │   ├── docs.md
+    │   ├── exec-plans.md
+    │   ├── generated-files.md
+    │   ├── git-workflow.md
+    │   ├── i18n.md
+    │   ├── project.md
+    │   └── testing.md
     │
     ├── CLAUDE.md .............. @AGENTS.md import + author rules
-    │   └── .claude/rules/ ..... domain-scoped rules (C++, CMake, docs, git)
+    │   └── .claude/rules/ ..... thin adapters importing .agents/rules/
     │
-    ├── GEMINI.md .............. @AGENTS.md import + author rules
+    ├── GEMINI.md .............. @AGENTS.md + .agents/rules/ imports + author rules
     │   └── .gemini/settings.json .. fileName reference to GEMINI.md
-    │
     ├── .codex/config.toml ..... project settings (native AGENTS.md discovery)
     │   └── .codex/rules/ ...... command execution control (Starlark)
     │
-    └── .coderabbit.yaml ....... independent config, aligned with AGENTS.md
+    └── .coderabbit.yaml ....... independent config, aligned with shared guidance
 ```
 
-## Shared Guidelines (AGENTS.md)
+## Bootstrap Guidelines (AGENTS.md)
 
-`AGENTS.md` at the repository root contains project-wide guidelines:
+`AGENTS.md` at the repository root is intentionally short. It contains:
 
-- Build commands (CMake, make, ctest)
-- Code formatting rules (clang-format, editorconfig)
-- Naming conventions (PascalCase, camelCase, snake_case)
-- Architecture overview (core/ vs gui/ separation)
-- Qt conventions (signal/slot syntax, parent ownership, tr())
-- Git workflow (Conventional Commits, branch naming, PR rules)
-- i18n setup (Qt translation tools)
-- Dependencies (vcpkg, Qt6, bundled libraries)
-- Pre-commit hooks
+- a project summary
+- instructions for loading `.agents/rules/*.md`
+- a rule index
+- critical guardrails that should remain visible before any path-specific rule
+  is selected
 
-**Update policy**: Always update AGENTS.md first. Tool-specific configs should never duplicate content that belongs in the shared file.
+**Update policy**: Put detailed guidance in `.agents/rules/`. Keep `AGENTS.md`
+as a bootstrap file unless a rule must be visible before path matching happens.
+Tool-specific configs should never duplicate content that belongs in the shared
+files.
+
+## Shared Path-Scoped Rules
+
+`.agents/rules/` stores reusable rule files with Markdown front matter:
+
+```yaml
+---
+paths:
+  - "**/*.cpp"
+  - "**/*.h"
+---
+```
+
+The `paths` list describes when the rule applies. Tools that support native
+path-scoped rules can import or adapt these files directly. Tools that cannot
+activate rules by path should load them as general context and use the `paths`
+front matter as an instruction hint.
+
+Current shared rules:
+
+| File | Purpose |
+|------|---------|
+| `.agents/rules/cmake.md` | CMake module, dependency, and test registration rules |
+| `.agents/rules/cpp-style.md` | C++17, Qt, ownership, and formatting rules |
+| `.agents/rules/design-files.md` | Pencil `.pen` design file handling |
+| `.agents/rules/docs.md` | English/Japanese documentation rules |
+| `.agents/rules/exec-plans.md` | Execution plan and tech-debt tracker rules |
+| `.agents/rules/generated-files.md` | Build outputs and generated file handling |
+| `.agents/rules/git-workflow.md` | Conventional Commits and release-please guardrails |
+| `.agents/rules/i18n.md` | Qt translation workflow |
+| `.agents/rules/project.md` | Build, architecture, dependencies, hooks, and harness rules |
+| `.agents/rules/testing.md` | Google Test and CTest rules |
+
+## Sync Workflow
+
+Run the sync script after changing `AGENTS.md` or `.agents/rules/*.md`:
+
+```bash
+scripts/sync-agent-rules.py
+```
+
+The script regenerates:
+
+| Output | Source | Purpose |
+|--------|--------|---------|
+| `.claude/rules/*.md` | `.agents/rules/*.md` | Claude Code path-scoped adapters |
+| `GEMINI.md` generated import block | `.agents/rules/*.md` | Gemini shared rule imports |
+
+Run the full harness check before opening a PR that changes the harness:
+
+```bash
+scripts/check-agent-harness.sh
+```
+
+The check syncs adapters, compiles the sync script, checks diff whitespace, and
+fails if generated adapters are stale.
+
+## Execution Plans
+
+Complex or long-running agent work should use checked-in execution plans under
+`docs/exec-plans/`. Plans are intentionally lighter than formal specifications;
+they preserve objective, scope, relevant rules, validation commands, decisions,
+and completion notes across tool sessions and context compaction.
+
+Use:
+
+- `docs/exec-plans/active/` for work in progress
+- `docs/exec-plans/completed/` for useful historical plans
+- `docs/exec-plans/tech-debt-tracker.md` for durable follow-up items
 
 ## Tool-Specific Configurations
 
@@ -51,22 +131,19 @@ AGENTS.md  (single source of truth)
 | File | Purpose |
 |------|---------|
 | `CLAUDE.md` | Imports AGENTS.md via `@AGENTS.md`, adds author attribution rules |
-| `.claude/rules/cpp-style.md` | C++17 style rules, scoped to `*.cpp, *.h, *.hpp` |
-| `.claude/rules/cmake.md` | CMake conventions, scoped to `CMakeLists.txt` |
-| `.claude/rules/docs.md` | Bilingual documentation rules, scoped to `docs/**` |
-| `.claude/rules/git-workflow.md` | Conventional Commits and branch naming rules |
+| `.claude/rules/*.md` | Path-scoped adapters that import matching `.agents/rules/*.md` files |
 | `.claude/settings.local.json` | Tool permissions (local, not committed) |
 
-**How it works**: Claude Code reads `CLAUDE.md` at startup, which uses `@AGENTS.md` to inline the shared guidelines. The `.claude/rules/` directory provides domain-specific rules that activate only when working on matching file paths.
+**How it works**: Claude Code reads `CLAUDE.md` at startup, which uses `@AGENTS.md` to inline the shared global guidelines. The `.claude/rules/` directory provides path-scoped adapters; each adapter keeps Claude's `paths` front matter and imports the matching shared rule from `.agents/rules/`.
 
 ### Gemini CLI
 
 | File | Purpose |
 |------|---------|
-| `GEMINI.md` | Imports AGENTS.md via `@AGENTS.md`, adds author attribution rules |
+| `GEMINI.md` | Imports AGENTS.md and `.agents/rules/*.md`, adds author attribution rules |
 | `.gemini/settings.json` | Points Gemini to read `GEMINI.md` as context |
 
-**How it works**: Gemini CLI reads `GEMINI.md` at startup, which uses `@AGENTS.md` to inline the shared guidelines. The `context.fileName` array in `.gemini/settings.json` tells Gemini CLI which files to load as persistent context.
+**How it works**: Gemini CLI reads `GEMINI.md` at startup. `GEMINI.md` imports `AGENTS.md` and each shared rule file. Gemini does not need its own path-scoped rule directory; it should use the `paths` front matter in shared rules as the applicability hint.
 
 ### OpenAI Codex
 
@@ -75,7 +152,7 @@ AGENTS.md  (single source of truth)
 | `.codex/config.toml` | Project-level settings (approval mode) |
 | `.codex/rules/project.rules` | Command execution control (Starlark) |
 
-**How it works**: Codex discovers `AGENTS.md` natively by walking the directory tree from the git root. No explicit reference is needed. The `.codex/config.toml` sets project defaults (e.g., `approval_mode`), and `.codex/rules/` controls which shell commands Codex can run without user approval.
+**How it works**: Codex discovers `AGENTS.md` natively by walking the directory tree from the git root. `AGENTS.md` points Codex to `.agents/rules/` for shared path-scoped guidance. The `.codex/config.toml` sets project defaults (e.g., `approval_mode`), and `.codex/rules/` controls which shell commands Codex can run without user approval.
 
 The rules file uses Starlark `prefix_rule()` to classify commands:
 - **allow** — build, test, format, read-only git operations
@@ -88,30 +165,37 @@ The rules file uses Starlark `prefix_rule()` to classify commands:
 |------|---------|
 | `.coderabbit.yaml` | PR review configuration with path-based instructions |
 
-**How it works**: CodeRabbit is a GitHub PR review bot. It does not read AGENTS.md directly, but its `path_instructions` section mirrors the same coding standards. It is configured independently but kept aligned with AGENTS.md.
+**How it works**: CodeRabbit is a GitHub PR review bot. It does not read AGENTS.md directly, but its `path_instructions` section mirrors the same coding standards. It is configured independently but kept aligned with AGENTS.md and `.agents/rules/`.
+
+When changing `.agents/rules/`, update `.coderabbit.yaml` if the same guidance
+should appear in PR review comments.
 
 ## Adding a New AI Tool
 
 When adding support for a new AI coding assistant:
 
-1. **Check native AGENTS.md support** — Many tools (Codex, Gemini CLI, Cursor, GitHub Copilot) can read AGENTS.md or similar markdown files. If supported, configure the tool to read it.
-2. **Create a tool-specific config** — Only add settings that are unique to the tool (e.g., permission models, approval modes, author attribution rules).
-3. **Do not duplicate AGENTS.md content** — The tool-specific config should reference or import the shared guidelines, not copy them.
-4. **Update this document** — Add the new tool to the Architecture diagram and Tool-Specific Configurations section.
+1. **Check native AGENTS.md support** — Many tools (Codex, Gemini CLI, etc.) can read AGENTS.md or similar markdown files. If supported, configure the tool to read it.
+2. **Create a thin adapter** — If the tool supports path-scoped rules, adapt `.agents/rules/` rather than writing new guidance.
+3. **Create tool-specific config only for tool behavior** — Permission models, approval modes, author attribution rules, and UI settings belong in tool-specific files.
+4. **Do not duplicate shared content** — The tool-specific config should reference or import shared guidance where possible.
+5. **Update this document** — Add the new tool to the Architecture diagram and Tool-Specific Configurations section.
 
 ## File Reference
 
 | File | Tool | Tracked | Description |
 |------|------|---------|-------------|
 | `AGENTS.md` | All | Yes | Shared project guidelines |
+| `.agents/README.md` | All | Yes | Shared rule schema and adapter policy |
+| `.agents/rules/*.md` | All | Yes | Shared path-scoped rules |
 | `CLAUDE.md` | Claude Code | Yes | Imports AGENTS.md + author rules |
-| `.claude/rules/*.md` | Claude Code | Yes | Domain-scoped rules |
+| `.claude/rules/*.md` | Claude Code | Yes | Path-scoped adapters importing shared rules |
 | `.claude/settings.local.json` | Claude Code | No | Local tool permissions |
-| `GEMINI.md` | Gemini CLI | Yes | Imports AGENTS.md + author rules |
+| `GEMINI.md` | Gemini CLI | Yes | Imports AGENTS.md, shared rules, and author rules |
 | `.gemini/settings.json` | Gemini CLI | Yes | Context file reference |
 | `.codex/config.toml` | OpenAI Codex | Yes | Project settings |
 | `.codex/rules/*.rules` | OpenAI Codex | Yes | Command execution rules |
 | `.coderabbit.yaml` | CodeRabbit | Yes | PR review configuration |
+| `scripts/sync-agent-rules.py` | All | Yes | Regenerates tool-specific adapters from shared rules |
 
 ## Related Documentation
 

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,30 @@
+# Execution Plans
+
+Execution plans are checked-in working notes for complex agent-driven tasks.
+They make intent, decisions, validation, and follow-up work visible to both
+humans and agents.
+
+Use an execution plan when a task spans multiple modules, requires multiple
+turns, changes architecture, or needs decisions that should survive context
+compaction.
+
+## Layout
+
+- `active/`: plans for work currently in progress
+- `completed/`: plans retained for historical context
+- `tech-debt-tracker.md`: known follow-up work and stale harness/docs items
+
+## Plan Shape
+
+Each plan should include:
+
+- objective
+- scope and non-goals
+- relevant rules/docs to consult
+- implementation steps
+- validation commands
+- decision log
+- completion notes
+
+Keep plans concise. They should guide work, not replace the code or the
+canonical documentation.

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,0 +1,9 @@
+# Active Execution Plans
+
+Place in-progress execution plans here.
+
+Use lowercase, hyphen-separated filenames, for example:
+
+```text
+agent-harness-ci.md
+```

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -1,0 +1,7 @@
+# Completed Execution Plans
+
+Move finished execution plans here when they remain useful as historical
+context.
+
+If a plan no longer provides useful context, remove it instead of preserving
+stale instructions.

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -1,0 +1,15 @@
+# Tech Debt Tracker
+
+Track known follow-up work that agents should be able to discover from the
+repository.
+
+## Open
+
+- Keep shared agent rules aligned with tool-specific adapter behavior as AI
+  tool formats evolve.
+- Consider adding ownership or freshness metadata to `.agents/rules/*.md` if
+  rule drift becomes difficult to review.
+
+## Closed
+
+No closed items yet.

--- a/scripts/check-agent-harness.sh
+++ b/scripts/check-agent-harness.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+snapshot_generated_adapters() {
+  {
+    [ -f GEMINI.md ] && printf '%s\n' GEMINI.md
+    [ -d .claude/rules ] && find .claude/rules -type f -name '*.md' -print
+  } | sort | while IFS= read -r path; do
+    shasum -a 256 "$path"
+  done
+}
+
+BEFORE_SNAPSHOT="$(mktemp)"
+AFTER_SNAPSHOT="$(mktemp)"
+trap 'rm -f "$BEFORE_SNAPSHOT" "$AFTER_SNAPSHOT"' EXIT
+
+snapshot_generated_adapters > "$BEFORE_SNAPSHOT"
+scripts/sync-agent-rules.py
+snapshot_generated_adapters > "$AFTER_SNAPSHOT"
+
+if ! diff -u "$BEFORE_SNAPSHOT" "$AFTER_SNAPSHOT"; then
+  echo "Agent harness adapters are out of sync. Run scripts/sync-agent-rules.py." >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+from pathlib import Path
+import ast
+
+ast.parse(Path("scripts/sync-agent-rules.py").read_text(encoding="utf-8"))
+PY
+
+git diff --check -- \
+  AGENTS.md \
+  .agents \
+  .claude/rules \
+  GEMINI.md \
+  docs/development/ai-agent-harness.md \
+  scripts/sync-agent-rules.py
+
+echo "Agent harness check passed."

--- a/scripts/sync-agent-rules.py
+++ b/scripts/sync-agent-rules.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Synchronize shared AI agent rules into tool-specific adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHARED_RULE_DIR = REPO_ROOT / ".agents" / "rules"
+CLAUDE_RULE_DIR = REPO_ROOT / ".claude" / "rules"
+GEMINI_FILE = REPO_ROOT / "GEMINI.md"
+
+BEGIN_GEMINI_IMPORTS = "<!-- BEGIN GENERATED AGENT RULE IMPORTS -->"
+END_GEMINI_IMPORTS = "<!-- END GENERATED AGENT RULE IMPORTS -->"
+
+
+@dataclass(frozen=True)
+class SharedRule:
+    slug: str
+    source_path: Path
+    paths: list[str]
+    body: str
+    title: str
+
+
+def parse_rule(path: Path) -> SharedRule:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise ValueError(f"{path} is missing front matter")
+
+    front_matter, body = text[4:].split("\n---\n", 1)
+    paths = parse_paths(front_matter, path)
+    title = parse_title(body, path)
+    return SharedRule(
+        slug=path.stem,
+        source_path=path,
+        paths=paths,
+        body=body.strip() + "\n",
+        title=title,
+    )
+
+
+def parse_paths(front_matter: str, path: Path) -> list[str]:
+    paths: list[str] = []
+    in_paths = False
+    for line in front_matter.splitlines():
+        if line.strip() == "paths:":
+            in_paths = True
+            continue
+        if in_paths and line.startswith("  - "):
+            paths.append(line.removeprefix("  - ").strip().strip('"'))
+            continue
+        if in_paths and line and not line.startswith(" "):
+            break
+
+    if not paths:
+        raise ValueError(f"{path} has no paths in front matter")
+    return paths
+
+
+def parse_title(body: str, path: Path) -> str:
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    raise ValueError(f"{path} has no H1 title")
+
+
+def yaml_list(items: list[str]) -> str:
+    return "\n".join(f'  - "{item}"' for item in items)
+
+
+def sync_claude(rule: SharedRule) -> None:
+    rel_source = f"../../.agents/rules/{rule.source_path.name}"
+    content = (
+        "---\n"
+        "paths:\n"
+        f"{yaml_list(rule.paths)}\n"
+        "---\n\n"
+        f"# {rule.title}\n\n"
+        f"@{rel_source}\n"
+    )
+    write_file(CLAUDE_RULE_DIR / f"{rule.slug}.md", content)
+
+
+def sync_gemini(rules: list[SharedRule]) -> None:
+    imports = "\n".join(f"@.agents/rules/{rule.source_path.name}" for rule in rules)
+    generated_block = (
+        f"{BEGIN_GEMINI_IMPORTS}\n"
+        f"{imports}\n"
+        f"{END_GEMINI_IMPORTS}"
+    )
+
+    text = GEMINI_FILE.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"{re.escape(BEGIN_GEMINI_IMPORTS)}.*?{re.escape(END_GEMINI_IMPORTS)}",
+        re.DOTALL,
+    )
+    if pattern.search(text):
+        text = pattern.sub(generated_block, text)
+    else:
+        heading = "## Shared Path-Scoped Rules"
+        if heading not in text:
+            raise ValueError(f"{GEMINI_FILE} is missing the shared rules section")
+        text = text.replace(heading, f"{heading}\n\n{generated_block}", 1)
+
+    write_file(GEMINI_FILE, text)
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> None:
+    rules = sorted(
+        (parse_rule(path) for path in SHARED_RULE_DIR.glob("*.md")),
+        key=lambda rule: rule.slug,
+    )
+    if not rules:
+        raise SystemExit("No shared agent rules found")
+
+    for rule in rules:
+        sync_claude(rule)
+    sync_gemini(rules)
+
+    print(f"Synchronized {len(rules)} shared agent rules")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Shorten AGENTS.md into a bootstrap file and move detailed guidance into shared .agents/rules/*.md files.
- Generate Claude and Gemini adapters from the shared rule source with scripts/sync-agent-rules.py.
- Add harness validation through scripts/check-agent-harness.sh, a pre-commit hook, and a GitHub Actions workflow.
- Add docs/exec-plans/ for durable agent execution plans and tech-debt tracking.

## Scope

This PR intentionally excludes the existing local changes in CMakeLists.txt and tests/DevToolsTests.cmake; those remain uncommitted for a separate change.

## Validation

- scripts/check-agent-harness.sh
- pre-commit run sync-agent-rules --all-files
- pre-commit hooks during commit
- pre-push build hook during git push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * AI コーディングアシスタント向けの統一ルールベースを確立し、複数ツール（Claude、Gemini、CodeRabbit等）間での一貫性を強化しました。

* **Chores**
  * AI エージェントハーネスの検証を自動化するGitHub Actions ワークフローと同期スクリプトを追加し、ツール別設定の一貫性を保つようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->