### PR TITLE
chore(agent): add OpenCode harness configuration

### DIFF
--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -56,6 +56,8 @@ commit message validation, and pre-push build verification.
 
 - `AGENTS.md` is the bootstrap instruction file for all AI coding tools.
 - Path-scoped, Claude Code-like rules live in `.agents/rules/`.
+- `opencode.json` loads all `.agents/rules/*.md` via the `instructions` field.
+  It is self-maintaining — no sync step required for OpenCode.
 - Tool-specific configs should import or mirror `.agents/rules/` instead of
   duplicating guidance.
 - After editing `AGENTS.md` or `.agents/rules/*.md`, run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This file is intentionally short. Detailed, path-scoped guidance lives in
 - Always read this file first.
 - For implementation details, consult every `.agents/rules/*.md` file whose
   `paths` front matter matches the files you will inspect or edit.
+  OpenCode loads these automatically via `opencode.json`.
 - Rules with `paths: ["**/*"]` apply globally.
 - After editing `AGENTS.md` or `.agents/rules/*.md`, run:
 

--- a/docs/development/ai-agent-harness.md
+++ b/docs/development/ai-agent-harness.md
@@ -29,6 +29,8 @@ AGENTS.md  (global source of truth)
     │   ├── project.md
     │   └── testing.md
     │
+    ├── opencode.json ......... loads .agents/rules/*.md via instructions glob
+    │
     ├── CLAUDE.md .............. @AGENTS.md import + author rules
     │   └── .claude/rules/ ..... thin adapters importing .agents/rules/
     │
@@ -102,6 +104,11 @@ The script regenerates:
 | `.claude/rules/*.md` | `.agents/rules/*.md` | Claude Code path-scoped adapters |
 | `GEMINI.md` generated import block | `.agents/rules/*.md` | Gemini shared rule imports |
 
+OpenCode does not require sync: `opencode.json` uses a glob pattern
+(`".agents/rules/*.md"`) in its `instructions` field, so it is
+self-maintaining — newly added or removed rule files are picked up
+automatically.
+
 Run the full harness check before opening a PR that changes the harness:
 
 ```bash
@@ -125,6 +132,22 @@ Use:
 - `docs/exec-plans/tech-debt-tracker.md` for durable follow-up items
 
 ## Tool-Specific Configurations
+
+### OpenCode
+
+| File | Purpose |
+|------|---------|
+| `AGENTS.md` | Bootstrap guidelines (auto-discovered by OpenCode) |
+| `opencode.json` | Project-level config with `instructions` glob to load `.agents/rules/*.md` |
+| `~/.config/opencode/AGENTS.md` | Personal global rules (not tracked) |
+| `.opencode/` | Custom agents, commands, skills, plugins (not tracked) |
+
+**How it works**: OpenCode reads `AGENTS.md` at startup and loads all
+`.agents/rules/*.md` files via the `instructions` array in `opencode.json`.
+The glob pattern matches all shared rule files, so new or removed rules are
+automatically picked up without running the sync script. Path-scoped rules
+are loaded as general context; OpenCode relies on the front matter `paths`
+hint to decide applicability.
 
 ### Claude Code
 
@@ -187,6 +210,7 @@ When adding support for a new AI coding assistant:
 | `AGENTS.md` | All | Yes | Shared project guidelines |
 | `.agents/README.md` | All | Yes | Shared rule schema and adapter policy |
 | `.agents/rules/*.md` | All | Yes | Shared path-scoped rules |
+| `opencode.json` | OpenCode | Yes | Project config with instructions glob |
 | `CLAUDE.md` | Claude Code | Yes | Imports AGENTS.md + author rules |
 | `.claude/rules/*.md` | Claude Code | Yes | Path-scoped adapters importing shared rules |
 | `.claude/settings.local.json` | Claude Code | No | Local tool permissions |

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [".agents/rules/*.md"]
+}

--- a/scripts/check-agent-harness.sh
+++ b/scripts/check-agent-harness.sh
@@ -38,6 +38,7 @@ git diff --check -- \
   .agents \
   .claude/rules \
   GEMINI.md \
+  opencode.json \
   docs/development/ai-agent-harness.md \
   scripts/sync-agent-rules.py
 


### PR DESCRIPTION
## Description / 説明

`opencode.json` を追加し、OpenCode が `.agents/rules/*.md` の共有ルールを自動的に読み込めるようにします。

OpenCode の `instructions` フィールドは glob パターンをサポートするため、ルールの追加・削除時に sync スクリプトを実行する必要がありません（self-maintaining）。

## Type of Change / 変更の種類

- [x] New feature (non-breaking change which adds functionality) / 新機能

## Checklist / チェックリスト

- [x] My code follows the style guidelines of this project / コードはこのプロジェクトのスタイルガイドラインに従っています
- [x] I have performed a self-review of my own code / 自分のコードのセルフレビューを行いました
- [x] I have made corresponding changes to the documentation / ドキュメントに対応する変更を加えました
- [x] My changes generate no new warnings / 変更によって新しい警告が発生していません

## 変更内容

- `opencode.json` (新規): `instructions: [".agents/rules/*.md"]` で共有ルールをロード
- `AGENTS.md`: OpenCode が opencode.json 経由でルールを読むことを注記
- `.agents/rules/project.md`: ハーネスセクションに OpenCode を追加
- `docs/development/ai-agent-harness.md`: アーキテクチャ図・ツール設定・ファイル参照テーブルを更新
- `scripts/check-agent-harness.sh`: opencode.json を diff-check 対象に追加