### PR TITLE
fix(data_conversion): resolve 4 ctest failures in parser and outdated flag

### DIFF
--- a/core/data_conversion/data_conversion.cpp
+++ b/core/data_conversion/data_conversion.cpp
@@ -178,7 +178,6 @@ void DataConversion::parseInputText()
     if (inputText().trimmed() == "") {
         inputFormat = Format::UNKNOWN;
         intermediateData = QVariant();
-        outdated = true;
         return;
     }
 
@@ -191,7 +190,6 @@ void DataConversion::parseInputText()
         inputFormat = Format::JSON;
         intermediateData = std::move(result.data);
         _messages = {tr("Parsed as JSON")};
-        outdated = true;
         return;
     }
 
@@ -202,7 +200,6 @@ void DataConversion::parseInputText()
         inputFormat = Format::TOML;
         intermediateData = std::move(result.data);
         _messages = {tr("Parsed as TOML")};
-        outdated = true;
         return;
     }
 
@@ -220,7 +217,6 @@ void DataConversion::parseInputText()
         }
 
         intermediateData = std::move(result.data);
-        outdated = true;
         return;
     }
 
@@ -228,5 +224,4 @@ void DataConversion::parseInputText()
     inputFormat = Format::ERROR;
     intermediateData = QVariant();
     _messages = {tr("Cannot parse input text")};
-    outdated = true;
 }

--- a/core/data_conversion/parser/toml_parser.cpp
+++ b/core/data_conversion/parser/toml_parser.cpp
@@ -48,7 +48,7 @@ struct Util
      */
     static QDate tomlDateToQDate(const TomlParser::toml_value_type::local_date_type &date)
     {
-        return {date.year, date.month, date.day};
+        return {date.year, date.month + 1, date.day};
     }
 
     /**

--- a/core/data_conversion/parser/yaml_parser.cpp
+++ b/core/data_conversion/parser/yaml_parser.cpp
@@ -1,6 +1,6 @@
 #include "yaml_parser.h"
 
-#include "core/exception/invalid_argument_exception.h"
+#include "core/exception/invalid_state_exception.h"
 
 #include <yaml-cpp/yaml.h>
 
@@ -88,8 +88,7 @@ YamlParser::ParseResult YamlParser::yamlScalarToQVariant(const YAML::Node &node)
             return result;
         } else {
             // 論理エラー; 到達不能の想定
-            throw InvalidArgumentException<bool>(
-                node.IsScalar(), "node is expected to be scalar type" + nodePosition(node));
+            throw InvalidStateException("node is expected to be scalar type" + nodePosition(node));
         }
     }
 
@@ -138,8 +137,7 @@ YamlParser::ParseResult YamlParser::yamlMapToQVariantMap(const YAML::Node &node)
             return result;
         } else {
             // 論理エラー; 到達不能の想定
-            throw InvalidArgumentException<bool>(
-                node.IsMap(), "node is expected to be map type" + nodePosition(node));
+            throw InvalidStateException("node is expected to be map type" + nodePosition(node));
         }
     }
 
@@ -174,8 +172,8 @@ YamlParser::ParseResult YamlParser::yamlSequenceToQVariantList(const YAML::Node 
             return result;
         } else {
             // 論理エラー; 到達不能の想定
-            throw InvalidArgumentException(
-                node.IsSequence(), "node is expected to be sequence type" + nodePosition(node));
+            throw InvalidStateException("node is expected to be sequence type" +
+                                        nodePosition(node));
         }
     }
 

--- a/core/data_conversion/parser/yaml_parser.h
+++ b/core/data_conversion/parser/yaml_parser.h
@@ -41,21 +41,21 @@ private:
     /**
      * @brief scalarを `QVariant` に変換する
      * @param node 変換前の値
-     * @exception InvalidArgumentException<bool> nodeが不正な場合
+     * @exception InvalidStateException nodeが不正な場合
      * @return 変換後の値 (dataは基本的に `QString` )
      */
     static ParseResult yamlScalarToQVariant(const YAML::Node &node) noexcept(false);
     /**
      * @brief mapを `QVariantMap` に変換する
      * @param node 変換前の値
-     * @exception InvalidArgumentException<bool> nodeが不正な場合
+     * @exception InvalidStateException nodeが不正な場合
      * @return 変換後の値
      */
     static ParseResult yamlMapToQVariantMap(const YAML::Node &node) noexcept(false);
     /**
      * @brief mapを `QVariantList` に変換する
      * @param node 変換前の値
-     * @exception InvalidArgumentException<bool> nodeが不正な場合
+     * @exception InvalidStateException nodeが不正な場合
      * @return 変換後の値
      */
     static ParseResult yamlSequenceToQVariantList(const YAML::Node &node) noexcept(false);

--- a/tests/core/data_conversion/test_data_conversion.cpp
+++ b/tests/core/data_conversion/test_data_conversion.cpp
@@ -201,8 +201,6 @@ void TestDataConversion::test_parseInputText()
         QCOMPARE_EQ(dataConversion.inputFormat, DataConversion::Format::UNKNOWN);
         // dataConversion.intermediateDataが空であること
         QCOMPARE_EQ(dataConversion.intermediateData, QVariant());
-        // outdatedがtrueになっていること
-        QCOMPARE_EQ(dataConversion.outdated, true);
     }
 
     QFile file(TEST_SRC_DIR + "/core/data_conversion/test.json");


### PR DESCRIPTION
## Description / 説明

Fix 4 failing ctest cases reported in #74.

### Root Causes / 原因

1. **yaml_parser** — `yamlScalarToQVariant` / `yamlMapToQVariantMap` / `yamlSequenceToQVariantList` threw `InvalidArgumentException<bool>` but tests expected `InvalidStateException`. These represent unreachable logic errors (wrong node type), semantically an invalid state.
2. **toml_parser** — `tomlDateToQDate()` passed toml11's 0-indexed `month_t` directly to 1-indexed `QDate`, producing dates one month early.
3. **data_conversion** — `parseInputText()` unconditionally set `outdated = true` in all branches, overriding `setInputText()`'s logic which only sets it when text changes.
4. **test_data_conversion** — `test_parseInputText` asserted `outdated == true` after calling `parseInputText()` directly without prior `setInputText()`, which no longer manages `outdated`.

### Changes / 変更内容

| File | Change |
|------|--------|
| `core/data_conversion/parser/yaml_parser.cpp` | Replace `InvalidArgumentException<bool>` throws with `InvalidStateException` (3 locations), update include |
| `core/data_conversion/parser/yaml_parser.h` | Update `@exception` doc tags |
| `core/data_conversion/parser/toml_parser.cpp:51` | `date.month` → `date.month + 1` in `tomlDateToQDate()` |
| `core/data_conversion/data_conversion.cpp` | Remove `outdated = true;` from all 5 branches in `parseInputText()` |
| `tests/core/data_conversion/test_data_conversion.cpp` | Remove stale `outdated` assertion from `test_parseInputText` |

### Verification / 検証

- `ctest --output-on-failure`: **22/22 passed (100%)**
- `cmake --build build --target format-check`: passed
- pre-push build check: passed

## Type of Change / 変更の種類

- [x] Bug fix

## Checklist / チェックリスト

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Fixes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TOML形式ファイルの日付解析における月の値の処理を修正しました。

* **Tests**
  * データ変換機能に関連するテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->