### PR TITLE
feat(build): add make run target with console output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,13 @@ else()
     )
 endif()
 
+add_custom_target(run
+    COMMAND ${CMAKE_BINARY_DIR}/DevTools.app/Contents/MacOS/DevTools
+    DEPENDS ${PROJECT_NAME}
+    COMMENT "Running DevTools with console output"
+    VERBATIM
+)
+
 add_custom_target(quality-check
     DEPENDS format-check lint
     COMMENT "Running all code quality checks"


### PR DESCRIPTION
## Description / 説明

`cmake --build build --target run` コマンドでアプリケーションをコンソール出力付きで実行できる `run` ターゲットを追加しました。

- バイナリを直接起動するため、stdout/stderr がターミナルに表示されます
- `DEPENDS ${PROJECT_NAME}` により実行前に自動ビルドが走ります

Fixes #12

## Type of Change / 変更の種類

- [x] New feature (non-breaking change which adds functionality) / 新機能（機能を追加する非破壊的変更）

## Checklist / チェックリスト

- [x] My code follows the style guidelines of this project / コードはこのプロジェクトのスタイルガイドラインに従っています
- [x] I have performed a self-review of my own code / 自分のコードのセルフレビューを行いました
- [x] My changes generate no new warnings / 変更によって新しい警告が発生していません
- [x] New and existing unit tests pass locally with my changes / 変更により新規および既存のユニットテストがローカルでパスします